### PR TITLE
feat #1: expand Jepsen workload and fault injection coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ pom.xml.asc
 
 # Environment configuration (local, not committed)
 .env
+
+# Clojure tooling (local dev only)
+.clj-kondo/
+.lsp/
+output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,71 @@
+# Build the dengine CLI binary from workspace root
+FROM rust:latest AS builder
+
+WORKDIR /build
+
+# Install the protobuf compiler
+RUN apt-get update && apt-get install -y protobuf-compiler
+
+# Disable sccache: .cargo/config.toml sets rustc-wrapper=sccache for local dev,
+# but sccache is not available in CI/Docker.
+ENV RUSTC_WRAPPER=""
+
+# Copy d-engine Rust workspace (passed via --build-context rust-workspace=../d-engine)
+COPY --from=rust-workspace . .
+
+# client-usage-standalone is excluded from the workspace; build from its own directory
+WORKDIR /build/examples/client-usage-standalone
+RUN cargo build --release
+
+# Use the JDK 21 base image (official ARM64 image)
 FROM eclipse-temurin:21-jdk-jammy
 
+# Install Leiningen
 RUN apt-get update && \
-    apt-get install -y curl git openssh-client procps net-tools gnuplot && \
+    apt-get install -y \
+    curl \
+    git \
+    gcc \
+    build-essential \
+    openssh-server \
+    telnet \
+    procps \
+    net-tools \
+    lsof \
+    gnuplot \
+    vim && \
     curl -L https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > /usr/local/bin/lein && \
     chmod +x /usr/local/bin/lein && \
     lein self-install && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
+# Install the Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+
+# Configure SSH Environment
 COPY sshkeys /root/.ssh
-RUN chmod 600 /root/.ssh/id_rsa
+RUN chmod 600 /root/.ssh/id_rsa && \
+    mkdir /var/run/sshd && \
+    echo 'root:root' | chpasswd && \
+    sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
-RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime && \
-    echo "UTC" > /etc/timezone
+# Set the time zone (Asia/Shanghai)
+RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone
 
+# Copy project files
 WORKDIR /app
 COPY src src
 COPY project.clj project.clj
+
+# Install Clojure dependencies
 RUN lein deps
 
-CMD ["tail", "-f", "/dev/null"]
+# Copy the compiled Rust binary
+COPY --from=builder /build/examples/client-usage-standalone/target/release/client-usage-standalone-demo /usr/local/bin/
+
+EXPOSE 22
+CMD ["/bin/sh", "-c", "/usr/sbin/sshd -D && eval $(ssh-agent -s) && ssh-add /root/.ssh/id_rsa"]

--- a/Makefile
+++ b/Makefile
@@ -1,81 +1,19 @@
-# d-engine-jepsen/Makefile
-.PHONY: test view report clean download-binaries check-binaries
-
-# Load environment from .env file if it exists
--include .env
-export
+# docker/jepsen/Makefile
+.PHONY: test view report clean
 
 # Configurable parameters
 TIME_LIMIT ?= 60
+TEST_COMMAND ?= client-usage-standalone-demo
+WORKLOAD ?= register
 NODE1 ?= node1
 NODE2 ?= node2
 NODE3 ?= node3
+JEPSEN_CONTAINER ?= d-engine-jepsen-jepsen-1
 ENDPOINTS ?= http://node1:9081,http://node2:9082,http://node3:9083
 COMPOSE_FILE ?= ./docker-compose.yml
 
-# Binary URLs and paths
-# S3_BASE_URL must be set in .env file (see .env.example)
-ifndef S3_BASE_URL
-$(error S3_BASE_URL is not defined. Please copy .env.example to .env and set S3_BASE_URL)
-endif
-BIN_DIR := ./bin
-EMBEDDED_BIN := $(BIN_DIR)/three-nodes-embedded-linux-amd64
-CTL_BIN := $(BIN_DIR)/dengine_ctl-linux-amd64
-CHECKSUM_FILE := $(BIN_DIR)/checksums.sha256
-
-# Download binaries from S3 if not present or checksum mismatch
-download-binaries:
-	@mkdir -p $(BIN_DIR)
-	@echo "Downloading checksums from S3..."
-	@curl -L -o $(CHECKSUM_FILE) $(S3_BASE_URL)/checksums.sha256
-	@echo "Verifying binaries..."
-	@if [ -f $(EMBEDDED_BIN) ] && [ -f $(CTL_BIN) ]; then \
-		shasum -a 256 -c $(CHECKSUM_FILE) --status 2>/dev/null; \
-		if [ $$? -eq 0 ]; then \
-			echo "✓ All binaries verified successfully"; \
-			exit 0; \
-		else \
-			echo "⚠ Checksum mismatch, re-downloading binaries..."; \
-			rm -f $(EMBEDDED_BIN) $(CTL_BIN); \
-		fi; \
-	fi
-	@if [ ! -f $(EMBEDDED_BIN) ]; then \
-		echo "Downloading three-nodes-embedded-linux-amd64..."; \
-		curl -L -o $(EMBEDDED_BIN) $(S3_BASE_URL)/three-nodes-embedded-linux-amd64; \
-		chmod +x $(EMBEDDED_BIN); \
-	fi
-	@if [ ! -f $(CTL_BIN) ]; then \
-		echo "Downloading dengine_ctl-linux-amd64..."; \
-		curl -L -o $(CTL_BIN) $(S3_BASE_URL)/dengine_ctl-linux-amd64; \
-		chmod +x $(CTL_BIN); \
-	fi
-	@echo "Verifying downloaded binaries..."
-	@shasum -a 256 -c $(CHECKSUM_FILE) --quiet
-	@echo "✓ Binary verification complete"
-
-# Force re-download binaries
-force-download:
-	@rm -f $(EMBEDDED_BIN) $(CTL_BIN)
-	@$(MAKE) download-binaries
-
-# Check if Docker images exist, build if missing
-check-images:
-	@echo "Checking Docker images..."
-	@if ! docker image inspect jepsen:2.0 > /dev/null 2>&1; then \
-		echo "Building missing Docker image: jepsen:2.0"; \
-		docker compose build jepsen; \
-	else \
-		echo "✓ jepsen:2.0 already exists"; \
-	fi
-	@if ! docker image inspect jepsen-node:2.0 > /dev/null 2>&1; then \
-		echo "Building missing Docker image: jepsen-node:2.0"; \
-		docker compose build node1; \
-	else \
-		echo "✓ jepsen-node:2.0 already exists"; \
-	fi
-
 # Restart Docker Compose stack
-restart-stack: check-images download-binaries
+restart-stack:
 	@echo "Cleaning output directories..."
 	@rm -rf ../output/logs/* ../output/db/*
 	@echo "Restarting Docker Compose stack..."
@@ -88,15 +26,19 @@ restart-stack: check-images download-binaries
 # Main test target
 test: restart-stack
 	@echo "Starting Jepsen test with time limit: ${TIME_LIMIT}s"
-	docker exec d-engine-jepsen-jepsen-1 lein run test \
-		--node $(NODE1) \
-		--node $(NODE2) \
-		--node $(NODE3) \
-		--ssh-private-key /root/.ssh/id_rsa \
-		--endpoints $(ENDPOINTS) \
-		--time-limit $(TIME_LIMIT)
+	docker exec -e SSH_AUTH_SOCK=/ssh-agent $(JEPSEN_CONTAINER) bash -c '\
+		  eval "$$(ssh-agent -s)" && \
+		  ssh-add /root/.ssh/id_rsa && \
+		  lein run test \
+		    --node '"${NODE1}"' \
+		    --node '"${NODE2}"' \
+		    --node '"${NODE3}"' \
+		    --endpoints '"${ENDPOINTS}"' \
+		    --time-limit '"${TIME_LIMIT}"' \
+		    --command '"${TEST_COMMAND}"' \
+		    --workload '"${WORKLOAD}"''
 	@echo "Jepsen test finished, checking result..."
-	docker exec d-engine-jepsen-jepsen-1 bash -c '\
+	docker exec $(JEPSEN_CONTAINER) bash -c '\
 		lein trampoline run -m clojure.main -e "\
 			(require '\''[knossos.model :as model])\
 			(println \
@@ -113,26 +55,28 @@ test: restart-stack
 # Set up SSH agent inside container
 ssh-setup:
 	@echo "Configuring SSH keys..."
-	@docker exec d-engine-jepsen-jepsen-1 bash -c "\
+	@docker exec $(JEPSEN_CONTAINER) bash -c "\
 		eval \$$(ssh-agent -s) && \
 		ssh-add /root/.ssh/id_rsa"
 
 # View latest test results
 view:
-	@if [ ! -d ./store/latest ]; then \
+	@latest=$$(readlink ./store/latest); \
+	if [ -z "$$latest" ]; then \
 		echo "No test results found"; \
 		exit 1; \
 	fi; \
-	open "$$(pwd)/store/latest/independent/0/linear/linear.html" 2>/dev/null || \
-	echo "Open manually: file://$$(pwd)/store/latest/independent/0/linear/linear.html"
+	open "$$(pwd)/store/$$latest/index.html" 2>/dev/null || \
+	echo "Open manually: file://$$(pwd)/$$latest/index.html"
 
 # Show path to latest report
 report:
-	@if [ ! -d ./store/latest ]; then \
+	@latest=$$(readlink ./store/latest); \
+	if [ -z "$$latest" ]; then \
 		echo "No test results available"; \
 		exit 1; \
 	fi; \
-	echo "Latest report: $$(pwd)/store/latest"
+	echo "Latest report: $$(pwd)/store/$$latest"
 
 # Clean test artifacts
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,19 @@
 # docker/jepsen/Makefile
-.PHONY: test view report clean
+.PHONY: test test-all view report clean restart-stack ssh-setup
 
 # Configurable parameters
-TIME_LIMIT ?= 60
-TEST_COMMAND ?= client-usage-standalone-demo
-WORKLOAD ?= register
-NODE1 ?= node1
-NODE2 ?= node2
-NODE3 ?= node3
+TIME_LIMIT       ?= 60
+TEST_COMMAND     ?= client-usage-standalone-demo
+WORKLOAD         ?= register
+FAULTS           ?= partition
+RATE             ?= 10
+NEMESIS_INTERVAL ?= 10
+NODE1            ?= node1
+NODE2            ?= node2
+NODE3            ?= node3
 JEPSEN_CONTAINER ?= d-engine-jepsen-jepsen-1
-ENDPOINTS ?= http://node1:9081,http://node2:9082,http://node3:9083
-COMPOSE_FILE ?= ./docker-compose.yml
+ENDPOINTS        ?= http://node1:9081,http://node2:9082,http://node3:9083
+COMPOSE_FILE     ?= ./docker-compose.yml
 
 # Restart Docker Compose stack
 restart-stack:
@@ -22,10 +25,11 @@ restart-stack:
 	@echo "Waiting for cluster to initialize (10 seconds)..."
 	@sleep 10
 
-
-# Main test target
+# Run a single workload.
+# Override any parameter on the command line, e.g.:
+#   make test WORKLOAD=bank FAULTS=kill,partition RATE=20 TIME_LIMIT=120
 test: restart-stack
-	@echo "Starting Jepsen test with time limit: ${TIME_LIMIT}s"
+	@echo "Starting Jepsen test: workload=$(WORKLOAD) faults=$(FAULTS) rate=$(RATE) time=$(TIME_LIMIT)s"
 	docker exec -e SSH_AUTH_SOCK=/ssh-agent $(JEPSEN_CONTAINER) bash -c '\
 		  eval "$$(ssh-agent -s)" && \
 		  ssh-add /root/.ssh/id_rsa && \
@@ -36,7 +40,10 @@ test: restart-stack
 		    --endpoints '"${ENDPOINTS}"' \
 		    --time-limit '"${TIME_LIMIT}"' \
 		    --command '"${TEST_COMMAND}"' \
-		    --workload '"${WORKLOAD}"''
+		    --workload '"${WORKLOAD}"' \
+		    --faults '"${FAULTS}"' \
+		    --rate '"${RATE}"' \
+		    --nemesis-interval '"${NEMESIS_INTERVAL}"''
 	@echo "Jepsen test finished, checking result..."
 	docker exec $(JEPSEN_CONTAINER) bash -c '\
 		lein trampoline run -m clojure.main -e "\
@@ -47,10 +54,25 @@ test: restart-stack
 						'\''knossos.model.Register model/->Register\
 						'\''knossos.model.CASRegister model/->CASRegister\
 						'\''knossos.model.Inconsistent model/->Inconsistent}\
-					}\
+					 :default (fn [_ v] v)}\
 					(slurp \"/app/store/latest/results.edn\"))\
 				:valid?)\
 				\"✅ PASS\" \"❌ FAIL\"))"'
+
+# Run all workloads sequentially against a fresh cluster each time.
+# Each workload exits non-zero on failure, stopping the suite early.
+#   make test-all
+#   make test-all FAULTS=kill,partition TIME_LIMIT=120
+test-all:
+	@echo "=== test-all: register ==="
+	$(MAKE) test WORKLOAD=register
+	@echo "=== test-all: bank ==="
+	$(MAKE) test WORKLOAD=bank
+	@echo "=== test-all: set ==="
+	$(MAKE) test WORKLOAD=set
+	@echo "=== test-all: append ==="
+	$(MAKE) test WORKLOAD=append
+	@echo "=== All workloads passed ✅ ==="
 
 # Set up SSH agent inside container
 ssh-setup:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ COMPOSE_FILE     ?= ./docker-compose.yml
 # Restart Docker Compose stack
 restart-stack:
 	@echo "Cleaning output directories..."
-	@rm -rf ../output/logs/* ../output/db/*
+	@rm -rf ./output/logs/* ./output/db/*
 	@echo "Restarting Docker Compose stack..."
 	@docker compose -f $(COMPOSE_FILE) down
 	@docker compose -f $(COMPOSE_FILE) up -d

--- a/config/n1.toml
+++ b/config/n1.toml
@@ -1,0 +1,87 @@
+# Docker Jepsen config for node 1.
+# initial_cluster uses container IPs (192.168.0.x) instead of 0.0.0.0,
+# which is required for inter-container Raft peer connections.
+
+[cluster]
+node_id = 1
+listen_address = "0.0.0.0:9081"
+initial_cluster = [
+    { id = 1, address = "192.168.0.11:9081", role = 1, status = 3 },
+    { id = 2, address = "192.168.0.12:9082", role = 1, status = 3 },
+    { id = 3, address = "192.168.0.13:9083", role = 1, status = 3 },
+]
+db_root_dir = "./db/1"
+log_dir = "./logs"
+
+[raft]
+general_raft_timeout_duration_in_ms = 100
+cmd_channel_capacity = 1024
+ordered_channel_capacity = 1024
+
+[raft.election]
+election_timeout_min = 1000
+election_timeout_max = 2000
+
+[raft.read_consistency]
+default_policy = "LeaseRead"
+lease_duration_ms = 500
+
+[raft.batching]
+max_batch_size = 200
+
+[raft.metrics]
+enable_backpressure = false
+enable_batch = false
+
+[raft.backpressure]
+max_pending_writes = 1000
+max_pending_reads = 500
+
+[raft.persistence]
+strategy = "MemFirst"
+flush_policy = { Batch = { idle_flush_interval_ms = 1000 } }
+max_buffered_entries = 10000
+
+[raft.snapshot]
+enable = false
+max_log_entries_before_snapshot = 10000
+snapshot_cool_down_since_last_check = { secs = 60 }
+snapshots_dir = "./snapshots/"
+retained_log_entries = 3
+
+[raft.state_machine.lease]
+enabled = true
+cleanup_interval_ms = 1000
+max_cleanup_duration_ms = 1
+
+[network.control]
+request_timeout_in_ms = 100
+concurrency_limit = 50
+max_concurrent_streams = 4096
+connection_window_size = 4_194_304
+initial_stream_window_size = 2_097_152
+enable_connect_protocol = true
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_max_pending_accept_reset_streams = 1000
+http2_max_send_buffer_size = 8_388_608
+
+[network.data]
+connect_timeout_in_ms = 100
+request_timeout_in_ms = 300
+concurrency_limit = 100
+max_concurrent_streams = 4096
+connection_window_size = 8_388_608
+initial_stream_window_size = 4_194_304
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_adaptive_window = true
+http2_max_pending_accept_reset_streams = 2000
+http2_max_send_buffer_size = 16_777_216
+
+[storage]
+unified_db = false

--- a/config/n2.toml
+++ b/config/n2.toml
@@ -1,0 +1,87 @@
+# Docker Jepsen config for node 2.
+# initial_cluster uses container IPs (192.168.0.x) instead of 0.0.0.0,
+# which is required for inter-container Raft peer connections.
+
+[cluster]
+node_id = 2
+listen_address = "0.0.0.0:9082"
+initial_cluster = [
+    { id = 1, address = "192.168.0.11:9081", role = 1, status = 3 },
+    { id = 2, address = "192.168.0.12:9082", role = 1, status = 3 },
+    { id = 3, address = "192.168.0.13:9083", role = 1, status = 3 },
+]
+db_root_dir = "./db/2"
+log_dir = "./logs"
+
+[raft]
+general_raft_timeout_duration_in_ms = 100
+cmd_channel_capacity = 1024
+ordered_channel_capacity = 1024
+
+[raft.election]
+election_timeout_min = 1000
+election_timeout_max = 2000
+
+[raft.read_consistency]
+default_policy = "LeaseRead"
+lease_duration_ms = 100
+
+[raft.batching]
+max_batch_size = 200
+
+[raft.metrics]
+enable_backpressure = false
+enable_batch = false
+
+[raft.backpressure]
+max_pending_writes = 1000
+max_pending_reads = 500
+
+[raft.persistence]
+strategy = "MemFirst"
+flush_policy = { Batch = { idle_flush_interval_ms = 1000 } }
+max_buffered_entries = 10000
+
+[raft.snapshot]
+enable = false
+max_log_entries_before_snapshot = 10000
+snapshot_cool_down_since_last_check = { secs = 60 }
+snapshots_dir = "./snapshots/"
+retained_log_entries = 3
+
+[raft.state_machine.lease]
+enabled = true
+cleanup_interval_ms = 1000
+max_cleanup_duration_ms = 1
+
+[network.control]
+request_timeout_in_ms = 100
+concurrency_limit = 50
+max_concurrent_streams = 4096
+connection_window_size = 4_194_304
+initial_stream_window_size = 2_097_152
+enable_connect_protocol = true
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_max_pending_accept_reset_streams = 1000
+http2_max_send_buffer_size = 8_388_608
+
+[network.data]
+connect_timeout_in_ms = 100
+request_timeout_in_ms = 300
+concurrency_limit = 100
+max_concurrent_streams = 4096
+connection_window_size = 8_388_608
+initial_stream_window_size = 4_194_304
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_adaptive_window = true
+http2_max_pending_accept_reset_streams = 2000
+http2_max_send_buffer_size = 16_777_216
+
+[storage]
+unified_db = false

--- a/config/n3.toml
+++ b/config/n3.toml
@@ -1,0 +1,87 @@
+# Docker Jepsen config for node 3.
+# initial_cluster uses container IPs (192.168.0.x) instead of 0.0.0.0,
+# which is required for inter-container Raft peer connections.
+
+[cluster]
+node_id = 3
+listen_address = "0.0.0.0:9083"
+initial_cluster = [
+    { id = 1, address = "192.168.0.11:9081", role = 1, status = 3 },
+    { id = 2, address = "192.168.0.12:9082", role = 1, status = 3 },
+    { id = 3, address = "192.168.0.13:9083", role = 1, status = 3 },
+]
+db_root_dir = "./db/3"
+log_dir = "./logs"
+
+[raft]
+general_raft_timeout_duration_in_ms = 100
+cmd_channel_capacity = 1024
+ordered_channel_capacity = 1024
+
+[raft.election]
+election_timeout_min = 1000
+election_timeout_max = 2000
+
+[raft.read_consistency]
+default_policy = "LeaseRead"
+lease_duration_ms = 100
+
+[raft.batching]
+max_batch_size = 200
+
+[raft.metrics]
+enable_backpressure = false
+enable_batch = false
+
+[raft.backpressure]
+max_pending_writes = 1000
+max_pending_reads = 500
+
+[raft.persistence]
+strategy = "MemFirst"
+flush_policy = { Batch = { idle_flush_interval_ms = 1000 } }
+max_buffered_entries = 10000
+
+[raft.snapshot]
+enable = false
+max_log_entries_before_snapshot = 10000
+snapshot_cool_down_since_last_check = { secs = 60 }
+snapshots_dir = "./snapshots/"
+retained_log_entries = 3
+
+[raft.state_machine.lease]
+enabled = true
+cleanup_interval_ms = 1000
+max_cleanup_duration_ms = 1
+
+[network.control]
+request_timeout_in_ms = 100
+concurrency_limit = 50
+max_concurrent_streams = 4096
+connection_window_size = 4_194_304
+initial_stream_window_size = 2_097_152
+enable_connect_protocol = true
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_max_pending_accept_reset_streams = 1000
+http2_max_send_buffer_size = 8_388_608
+
+[network.data]
+connect_timeout_in_ms = 100
+request_timeout_in_ms = 300
+concurrency_limit = 100
+max_concurrent_streams = 4096
+connection_window_size = 8_388_608
+initial_stream_window_size = 4_194_304
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_adaptive_window = true
+http2_max_pending_accept_reset_streams = 2000
+http2_max_send_buffer_size = 16_777_216
+
+[storage]
+unified_db = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,17 @@
 services:
   node1: &node-base
-    image: jepsen-node:2.0
-    build:
-      context: .
-      dockerfile: Dockerfile.node
-    hostname: node1
-    environment:
-      S3_BASE_URL: ${S3_BASE_URL}
-      D_ENGINE_BINARY: ${D_ENGINE_BINARY:-three-nodes-embedded-linux-amd64}
-      D_ENGINE_CTL_BINARY: ${D_ENGINE_CTL_BINARY:-dengine_ctl-linux-amd64}
+    image: demo:v0.2.4
     cap_add:
-      - NET_ADMIN
+      - NET_ADMIN # Add the NET_ADMIN capability
+    environment:
+      ID: 1
+      PROMETHEUS_PORT: 8081
+      LISTEN_PORT: 9081
+      LOG_LEVEL: debug
+      CONFIG_PATH: config/n1
+      LOG_DIR: ./logs/1
+      METRICS_PORT: 8081
+      PEERS: '[{"id": 2,"name":"n2", "ip":"192.168.0.12", "port":9082, "role": 1}, {"id": 3,"name":"n3", "ip":"192.168.0.13", "port":9083, "role": 1}]'
     networks:
       mynetwork:
         ipv4_address: 192.168.0.11
@@ -18,12 +19,23 @@ services:
       - "2021:22"
       - "9081:9081"
     volumes:
-      - ${SSH_KEYS_PATH:-./sshkeys}:/root/.ssh
-      - ./bin:/opt/d-engine/bin
+      - ${SSH_KEYS_PATH:-./jepsen/sshkeys}:/root/.ssh
+      - ${CONFIG_PATH:-./config}:/app/config
+      - ${LOGS_PATH:-./output/logs}:/app/logs
+      - ${DB_PATH:-./output/db}:/app/db
+      # - ${SNAPSHOTS_PATH:-./output/snapshots}:/app/snapshots
 
   node2:
     <<: *node-base
-    hostname: node2
+    environment:
+      ID: 2
+      PROMETHEUS_PORT: 8082
+      LISTEN_PORT: 9082
+      LOG_LEVEL: debug
+      CONFIG_PATH: config/n2
+      LOG_DIR: ./logs/2
+      METRICS_PORT: 8082
+      PEERS: '[{"id": 1,"name":"n1", "ip":"192.168.0.11", "port":9081, "role": 1}, {"id": 3,"name":"n3", "ip":"192.168.0.13", "port":9083, "role": 1}]'
     networks:
       mynetwork:
         ipv4_address: 192.168.0.12
@@ -33,7 +45,15 @@ services:
 
   node3:
     <<: *node-base
-    hostname: node3
+    environment:
+      ID: 3
+      PROMETHEUS_PORT: 8083
+      LISTEN_PORT: 9083
+      LOG_LEVEL: debug
+      CONFIG_PATH: config/n3
+      LOG_DIR: ./logs/3
+      METRICS_PORT: 8083
+      PEERS: '[{"id": 2,"name":"n2", "ip":"192.168.0.12", "port":9082, "role": 1}, {"id": 1,"name":"n1", "ip":"192.168.0.11", "port":9081, "role": 1}]'
     networks:
       mynetwork:
         ipv4_address: 192.168.0.13
@@ -46,17 +66,31 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      additional_contexts:
+        rust-workspace: ../d-engine
     cap_add:
-      - NET_ADMIN
+      - NET_ADMIN # Add the NET_ADMIN capability
+    environment:
+      N1: 192.168.0.11
+      N2: 192.168.0.12
+      N3: 192.168.0.13
+      ENDPOINTS: http://node3:9083/,http://node2:9082/,http://node1:9081/
+      TIME_LIMIT: 1
     networks:
       mynetwork:
         ipv4_address: 192.168.0.14
+    ports:
+      - "2024:22"
     volumes:
-      - ${JEP_STORE_PATH:-./store}:/app/store
+      - ${JEP_STORE_PATH:-./jepsen/store}:/app/store
     depends_on:
       - node1
       - node2
       - node3
+
+volumes:
+  prometheus_data:
+  grafana_data:
 
 networks:
   mynetwork:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jepsen.dengine "0.1.4"
+(defproject jepsen.dengine "0.2.4"
   :description "A Jepsen test for d-engine"
   :license {:name "MIT License"
             :url "https://opensource.org/licenses/MIT"}

--- a/src/jepsen/d_engine.clj
+++ b/src/jepsen/d_engine.clj
@@ -14,6 +14,7 @@
    [clojure.java.shell :as shell]
    [jepsen.d_engine.bank    :as bank]
    [jepsen.d_engine.set     :as set-workload]
+   [jepsen.d_engine.append  :as append-workload]
    [jepsen.d_engine.db      :as db-module]
    [jepsen.d_engine.nemesis :as d-nemesis]))
 
@@ -96,6 +97,7 @@
   (case (:workload opts)
     "bank"   (bank/workload opts)
     "set"    (set-workload/workload opts)
+    "append" (append-workload/workload opts)
     (register-workload opts)))
 
 ;; ========== Test spec ==========
@@ -145,7 +147,7 @@
    ["-w" "--workload NAME" "Workload: register (default), bank, set"
     :default  "register"
     :parse-fn identity
-    :validate [#{"register" "bank" "set"} "must be one of: register, bank, set"]]
+    :validate [#{"register" "bank" "set" "append"} "must be one of: register, bank, set, append"]]
 
    [nil "--faults FAULTS" "Nemesis faults (comma-separated: partition,kill,pause / all / none)"
     :default  [:partition]

--- a/src/jepsen/d_engine.clj
+++ b/src/jepsen/d_engine.clj
@@ -15,6 +15,8 @@
    [jepsen.control.util :as cu]
    [jepsen.d-engine.db :as d-db]
    [jepsen.d-engine.nemesis :as d-nemesis]
+   [jepsen.d-engine.bank :as bank]
+   [jepsen.d-engine.set :as set-workload]
    [jepsen.os.debian :as debian]
    [knossos.model :as model]
    [slingshot.slingshot :refer [try+]]))
@@ -128,11 +130,32 @@
                                     :algorithm :linear})
      :timeline (timeline/html)})))
 
+(defn register-workload [opts]
+  {:client    (Client. nil nil (:endpoints opts))
+   :checker   (independent/checker
+               (checker/compose
+                {:linear   (checker/linearizable {:model     (model/cas-register)
+                                                   :algorithm :linear})
+                 :timeline (timeline/html)}))
+   :generator (independent/concurrent-generator
+               3
+               (range 3)
+               (fn [k]
+                 (->> (gen/mix [r w])
+                      (gen/stagger 1/2)
+                      (gen/limit 40))))})
+
+(defn workload [opts]
+  (case (:workload opts)
+    "bank" (bank/workload opts)
+    "set"  (set-workload/workload opts)
+    (register-workload opts)))
+
 (defn test-spec
   [opts]
   (println "opts:" opts)
   (println "Time limit set to:" (:time-limit opts))
-  (let [db (d-db/db)
+  (let [db      (d-db/db)
         nemesis (d-nemesis/nemesis-package
                  {:db        db
                   :nodes     (:nodes opts)
@@ -140,35 +163,31 @@
                   :partition {:targets [:majority]}
                   :pause     {:targets [:all]}
                   :kill      {:targets [:all]}
-                  :interval  5})]
+                  :interval  5})
+        wl      (workload opts)]
     (merge tests/noop-test
            opts
-           {:name "d-engine"
-            :os   debian/os
-            :db   db
-            :client  (Client. nil nil (:endpoints opts))
+           {:name    (str "d-engine-" (:workload opts "register"))
+            :os      debian/os
+            :db      db
+            :client  (:client wl)
             :nemesis (:nemesis nemesis)
-            :checker (independent/checker
-                      (checker/compose
-                       {:linear (checker/linearizable {:model     (model/cas-register)
-                                                       :algorithm :linear})
-                        :timeline (timeline/html)}))
-            :generator (->> (independent/concurrent-generator
-                             3
-                             (range 3)
-                             (fn [k]
-                               (->> (gen/mix [r w])
-                                    (gen/stagger 1/2)
-                                    (gen/limit 40))))
+            :checker (:checker wl)
+            :generator (->> (:generator wl)
+                            (gen/stagger 1/10)
                             (gen/nemesis (:generator nemesis))
                             (gen/time-limit (:time-limit opts)))})))
 
 (def cli-opts
   "Additional command line options."
-  [["-e" "--endpoints ENDPOINTS" "The endpoints for the d-engine cluster."
+  [["-e" "--endpoints ENDPOINTS" "d-engine gRPC endpoints (comma-separated)"
     :default "http://node1:9081,http://node2:9082,http://node3:9083"
     :parse-fn identity
-    :validate [(complement empty?) "Endpoints cannot be empty."]]])
+    :validate [(complement empty?) "Endpoints cannot be empty."]]
+   ["-w" "--workload NAME" "Workload to run: register (default), bank, set"
+    :default "register"
+    :parse-fn identity
+    :validate [#{"register" "bank" "set"} "must be one of: register, bank, set"]]])
 
 (defn -main
   "handles command lien arguments"

--- a/src/jepsen/d_engine.clj
+++ b/src/jepsen/d_engine.clj
@@ -1,205 +1,169 @@
 (ns jepsen.d_engine
   (:require
-   [clojure.tools.logging :refer :all]
+   [clojure.tools.logging :refer [info]]
    [clojure.string :as str]
-   [verschlimmbesserung.core :as v]
    [jepsen [checker :as checker]
-    [cli :as cli]
-    [client :as client]
-    [control :as c]
-    [generator :as gen]
-    [independent :as independent]
-    [nemesis :as nemesis]
-    [tests :as tests]]
+            [cli :as cli]
+            [client :as client]
+            [generator :as gen]
+            [independent :as independent]
+            [tests :as tests]]
    [jepsen.checker.timeline :as timeline]
-   [jepsen.control.util :as cu]
-   [clojure.java.shell :as shell]
-   [jepsen.os :as os]
    [knossos.model :as model]
    [slingshot.slingshot :refer [try+]]
-   [clojure.tools.cli :refer [parse-opts]]
-   [jepsen.d_engine.bank :as bank]
-   [jepsen.d_engine.set :as set-workload]))
+   [clojure.java.shell :as shell]
+   [jepsen.d_engine.bank    :as bank]
+   [jepsen.d_engine.set     :as set-workload]
+   [jepsen.d_engine.db      :as db-module]
+   [jepsen.d_engine.nemesis :as d-nemesis]))
 
-;; ========== Operation Definition ==========
-;; Update operation commands to match v0.1.4 API
-(defn r [_ _] {:type :invoke, :f :read, :value nil})
+;; ========== Nemesis spec ==========
+
+(def special-nemeses
+  {:none []
+   :all  [:partition :kill :pause]})
+
+(defn parse-nemesis-spec [spec]
+  (->> (str/split spec #",")
+       (map keyword)
+       (mapcat #(get special-nemeses % [%]))))
+
+;; ========== Register workload ==========
+
+(defn r [_ _] {:type :invoke, :f :read,  :value nil})
 (defn w [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
 
-;; Adjust mixed ratio: 70% linear reads + 30% normal reads
-(def mixed-reads (gen/mix [{:weight 7, :gen r} {:weight 3, :gen r}]))
-
-;; ========== Command execution tool ==========
-(defn ctl-command
-  "Execute the dengine_ctl command and process the output"
-  [cmd & args]
-  (let [command (concat [cmd] args) ; Ensure everything is a string
-        _ (info "Executing command: " (pr-str command))  ; Better logging
-        result (apply shell/sh command)] ; Add Rust debugging information
-    (println "Executing command:" command)  ;; Log the command being executed
-    (info "Command output:" (:out result))
-    (info "Command error:" (:err result))
+(defn ctl-command [cmd & args]
+  (let [result (apply shell/sh cmd args)]
+    (info "cmd:" (pr-str (cons cmd args))
+          "exit:" (:exit result)
+          "out:"  (:out result))
     (if (zero? (:exit result))
-      (do
-        (println "Success:" (:out result))  ;; Log success output
-        (:out result))
+      (:out result)
       (throw (ex-info "Command failed"
                       {:exit (:exit result)
-                       :err (:err result)
-                       :out (:out result)})))))
+                       :err  (:err result)
+                       :out  (:out result)})))))
 
-;; ========== Client Implementation ==========
-(defn parse-long-nil
-  "Parses a string to a Long. Passes through `nil`."
-  [s]
-  (println "Parsing raw string:" (pr-str s))
+(defn parse-long-nil [s]
   (when s
-    (try
-      (-> s
-          (clojure.string/trim) ; Clean leading and trailing whitespace (including newlines)
-          (Long/parseLong))
-      (catch NumberFormatException _
-        nil)))) ; Return nil if parsing fails
+    (try (-> s str/trim Long/parseLong)
+         (catch NumberFormatException _ nil))))
 
-(defn client
-  "A client for a single compare-and-set register"
-  [cmd endpoints]
-  (assert (string? endpoints) (str "ENDPOINTS MUST BE STRING. GOT: " endpoints))
+(defn register-client [cmd endpoints]
   (reify client/Client
-
-    (open! [this test node]
-      (info "Opening client for node:" node)
-      this)
-
-    (invoke! [this test op]
-      (println "Received operation:" op)
-      (let [[k v] (:value op)
-            ; Read operation failures are marked as :fail, write operations are marked as :info
-            crash-type (if (#{:get :lget} (:f op)) :fail :info)]
+    (open!    [this test node] this)
+    (setup!   [_ _])
+    (teardown![_ _])
+    (close!   [_ _])
+    (invoke!  [_ test op]
+      (let [[k v]       (:value op)
+            crash-type  (if (= :read (:f op)) :fail :info)]
         (try+
-         (case (:f op)
-            ; Linear read (lget)
-           :read (let [result (parse-long-nil
+          (case (:f op)
+            :read  (let [res (parse-long-nil
                                (ctl-command cmd "--endpoints" endpoints "lget" (str k)))]
-                   (if result
-                     (assoc op :type :ok, :value (independent/tuple k result))
-                     (assoc op :type :fail, :error :not-found)))
+                     (if res
+                       (assoc op :type :ok, :value (independent/tuple k res))
+                       (assoc op :type :fail, :error :not-found)))
+            :write (do (ctl-command cmd "--endpoints" endpoints "put" (str k) (str v))
+                       (assoc op :type :ok)))
+          (catch clojure.lang.ExceptionInfo e
+            (let [err (str (ex-message e) " " (pr-str (ex-data e)))]
+              (cond
+                (re-find #"(?i)cluster unavailable|timeout|deadline exceeded|not leader" err)
+                (assoc op :type crash-type :error [:unavailable err])
+                :else
+                (assoc op :type crash-type :error [:unknown err])))))))))
 
-; Write operation (put)
-           :write (do
-                    (println "endpoints:" endpoints "; Putting value:" v "for key:" k)
-                    (ctl-command cmd "--endpoints" endpoints "put" (str k) (str v))
-                    (assoc op :type :ok)))
-
-; ===== Error handling =====
-         (catch java.net.SocketTimeoutException e
-           (assoc op :type crash-type, :error :timeout))
-
-         (catch [:exit 4005] e ; cluster not available
-           (assoc op :type crash-type :error :cluster-unavailable))
-
-         (catch Exception e
-           (let [err-msg (or (.getMessage e)
-                             (some-> e ex-data :err)
-                             (some-> e ex-data :body))]
-             (cond
-               (and err-msg (str/includes? (str/lower-case err-msg) "key not found"))
-               (assoc op :type :fail :error :not-found)
-
-               (and err-msg (str/includes? (str/lower-case err-msg) "cluster unavailable"))
-               (assoc op :type crash-type :error :cluster-unavailable)
-
-               :else
-               (assoc op :type crash-type :error (or err-msg "unknown error"))))))))
-
-    (close! [_ _]
-      (info "Closing client"))
-
-    (setup! [_ _])
-    (teardown! [_ _])))
-
-;; ========== Checker Implementation ==========
-(defn split-history
-  "Split History: Linear Reads vs. Normal Operations"
-  [history]
-  (group-by (fn [op] (if (= :lget (:f op)) :lget-ops :other-ops)) history))
-
-(defn checker
-  "Linearizability checker"
-  [test history opts]
-  (independent/checker
-   (checker/compose
-    {;; :perf   (checker/perf)
-     :linear (checker/linearizable {:model     (model/cas-register)
-                                    :algorithm :linear})
-     :timeline (timeline/html)})))
-
-(defn register-workload
-  "Original linearizable register workload."
-  [opts]
-  {:client    (client (:command opts) (:endpoints opts))
-   :checker   (independent/checker
-               (checker/compose
-                {:linear   (checker/linearizable {:model     (model/cas-register)
-                                                  :algorithm :auto})
-                 :timeline (timeline/html)}))
+(defn register-workload [opts]
+  {:client  (register-client (:command opts) (:endpoints opts))
+   :checker (independent/checker
+              (checker/compose
+               {:linear   (checker/linearizable {:model     (model/cas-register)
+                                                 :algorithm :auto})
+                :timeline (timeline/html)}))
    :generator (independent/concurrent-generator
-               3
-               (range 3)
-               (fn [k]
-                 (->> (gen/mix [r w])
-                      (gen/stagger 1/2)
-                      (gen/limit 40))))})
+                3 (range 3)
+                (fn [k]
+                  (->> (gen/mix [r w])
+                       (gen/stagger 1/2)
+                       (gen/limit 40))))})
 
-(defn workload
-  [opts]
+;; ========== Workload dispatch ==========
+
+(defn workload [opts]
   (case (:workload opts)
-    "bank" (bank/workload opts)
-    "set"  (set-workload/workload opts)
+    "bank"   (bank/workload opts)
+    "set"    (set-workload/workload opts)
     (register-workload opts)))
 
-(defn test-spec
-  [opts]
-  (println "opts:" opts)
-  (println "Time limit set to:" (:time-limit opts))
-  (let [wl (workload opts)]
+;; ========== Test spec ==========
+
+(defn test-spec [opts]
+  (let [wl  (workload opts)
+        db  (db-module/db)
+        nem (d-nemesis/nemesis-package
+              {:db        db
+               :nodes     (:nodes opts)
+               :faults    (set (:faults opts))
+               :partition {:targets [:majority :primaries]}
+               :pause     {:targets [:all]}
+               :kill      {:targets [:all]}
+               :interval  (:nemesis-interval opts)})
+        gen (->> (:generator wl)
+                 (gen/stagger (/ 1 (:rate opts)))
+                 (gen/nemesis
+                   (gen/phases
+                     (gen/sleep 5)
+                     (:generator nem)))
+                 (gen/time-limit (:time-limit opts)))]
     (merge tests/noop-test
+           opts
            {:name      (str "d-engine-" (:workload opts "register"))
-            :ssh       {:private-key-path "/root/.ssh/id_rsa"
+            :ssh       {:private-key-path        "/root/.ssh/id_rsa"
                         :strict-host-key-checking false}
+            :db        db
             :client    (:client wl)
-            :nemesis   (nemesis/partition-random-halves)
+            :nemesis   (:nemesis nem)
             :checker   (:checker wl)
-            :generator (->> (:generator wl)
-                            (gen/stagger 1/10)
-                            (gen/nemesis
-                             (cycle [(gen/sleep 10)
-                                     {:type :info, :f :start}
-                                     (gen/sleep 5)
-                                     {:type :info, :f :stop}]))
-                            (gen/time-limit (:time-limit opts)))}
-           opts)))
+            :generator gen})))
+
+;; ========== CLI ==========
 
 (def cli-opts
-  "Additional command line options."
-  [["-c" "--command CMD" "CLI binary path"
-    :default "client-usage-standalone-demo"
+  [[nil "--command CMD" "CLI binary path"
+    :default  "client-usage-standalone-demo"
     :parse-fn identity
     :validate [(complement empty?) "command cannot be empty."]]
-   ["-e" "--endpoints ENDPOINTS" "d-engine gRPC endpoints (comma-separated)"
-    :default "http://node1:9080,http://node2:9080,http://node3:9080"
+
+   [nil "--endpoints ENDPOINTS" "d-engine endpoints (comma-separated)"
+    :default  "http://node1:9081/,http://node2:9082/,http://node3:9083/"
     :parse-fn identity
     :validate [(complement empty?) "endpoints cannot be empty."]]
-   ["-w" "--workload NAME" "Workload to run: register (default), bank, set"
-    :default "register"
-    :parse-fn identity
-    :validate [#{"register" "bank" "set"} "must be one of: register, bank, set"]]])
 
-(defn -main
-  "handles command lien arguments"
-  [& args]
+   ["-w" "--workload NAME" "Workload: register (default), bank, set"
+    :default  "register"
+    :parse-fn identity
+    :validate [#{"register" "bank" "set"} "must be one of: register, bank, set"]]
+
+   [nil "--faults FAULTS" "Nemesis faults (comma-separated: partition,kill,pause / all / none)"
+    :default  [:partition]
+    :parse-fn parse-nemesis-spec]
+
+   [nil "--rate RATE" "Target ops/sec"
+    :default  10
+    :parse-fn read-string
+    :validate [pos? "rate must be positive"]]
+
+   [nil "--nemesis-interval SECS" "Seconds between nemesis operations"
+    :default  10
+    :parse-fn read-string
+    :validate [pos? "nemesis-interval must be positive"]]])
+
+(defn -main [& args]
   (cli/run!
-   (merge (cli/single-test-cmd {:test-fn test-spec
-                                :opt-spec cli-opts})
-          (cli/serve-cmd))
-   args))
+    (merge (cli/single-test-cmd {:test-fn  test-spec
+                                 :opt-spec cli-opts})
+           (cli/serve-cmd))
+    args))

--- a/src/jepsen/d_engine.clj
+++ b/src/jepsen/d_engine.clj
@@ -2,117 +2,121 @@
   (:require
    [clojure.tools.logging :refer :all]
    [clojure.string :as str]
+   [verschlimmbesserung.core :as v]
    [jepsen [checker :as checker]
     [cli :as cli]
     [client :as client]
     [control :as c]
-    [db :as db]
     [generator :as gen]
     [independent :as independent]
     [nemesis :as nemesis]
     [tests :as tests]]
    [jepsen.checker.timeline :as timeline]
    [jepsen.control.util :as cu]
-   [jepsen.d-engine.db :as d-db]
-   [jepsen.d-engine.nemesis :as d-nemesis]
-   [jepsen.d-engine.bank :as bank]
-   [jepsen.d-engine.set :as set-workload]
-   [jepsen.os.debian :as debian]
+   [clojure.java.shell :as shell]
+   [jepsen.os :as os]
    [knossos.model :as model]
-   [slingshot.slingshot :refer [try+]]))
+   [slingshot.slingshot :refer [try+]]
+   [clojure.tools.cli :refer [parse-opts]]
+   [jepsen.d_engine.bank :as bank]
+   [jepsen.d_engine.set :as set-workload]))
 
 ;; ========== Operation Definition ==========
+;; Update operation commands to match v0.1.4 API
 (defn r [_ _] {:type :invoke, :f :read, :value nil})
 (defn w [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
 
-;; ========== Client Implementation ==========
-(def ctl-bin (str "/opt/d-engine/bin/"
-                  (or (System/getenv "D_ENGINE_CTL_BINARY")
-                      "dengine_ctl-linux-amd64")))
+;; Adjust mixed ratio: 70% linear reads + 30% normal reads
+(def mixed-reads (gen/mix [{:weight 7, :gen r} {:weight 3, :gen r}]))
 
+;; ========== Command execution tool ==========
+(defn ctl-command
+  "Execute the dengine_ctl command and process the output"
+  [cmd & args]
+  (let [command (concat [cmd] args) ; Ensure everything is a string
+        _ (info "Executing command: " (pr-str command))  ; Better logging
+        result (apply shell/sh command)] ; Add Rust debugging information
+    (println "Executing command:" command)  ;; Log the command being executed
+    (info "Command output:" (:out result))
+    (info "Command error:" (:err result))
+    (if (zero? (:exit result))
+      (do
+        (println "Success:" (:out result))  ;; Log success output
+        (:out result))
+      (throw (ex-info "Command failed"
+                      {:exit (:exit result)
+                       :err (:err result)
+                       :out (:out result)})))))
+
+;; ========== Client Implementation ==========
 (defn parse-long-nil
-  "Parses a string to a Long. Returns nil on failure."
+  "Parses a string to a Long. Passes through `nil`."
   [s]
+  (println "Parsing raw string:" (pr-str s))
   (when s
     (try
-      (Long/parseLong (str/trim s))
-      (catch NumberFormatException _ nil))))
+      (-> s
+          (clojure.string/trim) ; Clean leading and trailing whitespace (including newlines)
+          (Long/parseLong))
+      (catch NumberFormatException _
+        nil)))) ; Return nil if parsing fails
 
-(defrecord Client [session node endpoints]
-  client/Client
+(defn client
+  "A client for a single compare-and-set register"
+  [cmd endpoints]
+  (assert (string? endpoints) (str "ENDPOINTS MUST BE STRING. GOT: " endpoints))
+  (reify client/Client
 
-  (open! [this test node]
-    (info "Opening client for node:" node)
-    (assoc this
-           :session (c/session node)
-           :node node))
+    (open! [this test node]
+      (info "Opening client for node:" node)
+      this)
 
-  (setup! [this test])
-
-  (invoke! [this test op]
-    (let [[k v] (:value op)]
-      (c/with-session node session
+    (invoke! [this test op]
+      (println "Received operation:" op)
+      (let [[k v] (:value op)
+            ; Read operation failures are marked as :fail, write operations are marked as :info
+            crash-type (if (#{:get :lget} (:f op)) :fail :info)]
         (try+
          (case (:f op)
-           :read
-           (let [result (parse-long-nil
-                         (c/exec ctl-bin :--endpoints endpoints :lget (str k)))]
-             (if result
-               (assoc op :type :ok :value (independent/tuple k result))
-               (assoc op :type :fail :error :not-found)))
+            ; Linear read (lget)
+           :read (let [result (parse-long-nil
+                               (ctl-command cmd "--endpoints" endpoints "lget" (str k)))]
+                   (if result
+                     (assoc op :type :ok, :value (independent/tuple k result))
+                     (assoc op :type :fail, :error :not-found)))
 
-           :write
-           (do
-             (c/exec ctl-bin :--endpoints endpoints :put (str k) (str v))
-             (assoc op :type :ok)
-             )
-           )
+; Write operation (put)
+           :write (do
+                    (println "endpoints:" endpoints "; Putting value:" v "for key:" k)
+                    (ctl-command cmd "--endpoints" endpoints "put" (str k) (str v))
+                    (assoc op :type :ok)))
 
-         (catch [:type :jepsen.control/nonzero-exit] e
-           (let [err (str (:err e) (:out e))]
+; ===== Error handling =====
+         (catch java.net.SocketTimeoutException e
+           (assoc op :type crash-type, :error :timeout))
+
+         (catch [:exit 4005] e ; cluster not available
+           (assoc op :type crash-type :error :cluster-unavailable))
+
+         (catch Exception e
+           (let [err-msg (or (.getMessage e)
+                             (some-> e ex-data :err)
+                             (some-> e ex-data :body))]
              (cond
-               ;; Definite failures - operation definitely did not occur
-               (re-find #"(?i)key not found" err)
-               (assoc op :type :fail :error [:not-found err])
+               (and err-msg (str/includes? (str/lower-case err-msg) "key not found"))
+               (assoc op :type :fail :error :not-found)
 
-               (re-find #"(?i)connection refused|no route to host" err)
-               (assoc op :type :fail :error [:connection-refused err])
+               (and err-msg (str/includes? (str/lower-case err-msg) "cluster unavailable"))
+               (assoc op :type crash-type :error :cluster-unavailable)
 
-               (re-find #"(?i)invalid argument" err)
-               (assoc op :type :fail :error [:invalid-argument err])
-
-               ;; Indefinite failures - operation outcome unknown
-               ;; For writes: might have succeeded before crash
-               ;; For reads: use :fail to be conservative
-               (re-find #"(?i)cluster unavailable" err)
-               (assoc op :type (if (= :read (:f op)) :fail :info)
-                      :error [:cluster-unavailable err])
-
-               (re-find #"(?i)timeout|deadline exceeded" err)
-               (assoc op :type (if (= :read (:f op)) :fail :info)
-                      :error [:timeout err])
-
-               (re-find #"(?i)leader changed|not leader" err)
-               (assoc op :type (if (= :read (:f op)) :fail :info)
-                      :error [:leadership-change err])
-
-               ;; Unknown errors - treat as indefinite for safety
                :else
-               (assoc op :type (if (= :read (:f op)) :fail :info)
-                      :error [:unknown err])
-               )
-             )
-           )
-        )
-      )
-    )
-  )
+               (assoc op :type crash-type :error (or err-msg "unknown error"))))))))
 
-  (teardown! [this test])
+    (close! [_ _]
+      (info "Closing client"))
 
-  (close! [this test]
-    (when session
-      (c/disconnect session))))
+    (setup! [_ _])
+    (teardown! [_ _])))
 
 ;; ========== Checker Implementation ==========
 (defn split-history
@@ -130,12 +134,14 @@
                                     :algorithm :linear})
      :timeline (timeline/html)})))
 
-(defn register-workload [opts]
-  {:client    (Client. nil nil (:endpoints opts))
+(defn register-workload
+  "Original linearizable register workload."
+  [opts]
+  {:client    (client (:command opts) (:endpoints opts))
    :checker   (independent/checker
                (checker/compose
                 {:linear   (checker/linearizable {:model     (model/cas-register)
-                                                   :algorithm :linear})
+                                                  :algorithm :auto})
                  :timeline (timeline/html)}))
    :generator (independent/concurrent-generator
                3
@@ -145,7 +151,8 @@
                       (gen/stagger 1/2)
                       (gen/limit 40))))})
 
-(defn workload [opts]
+(defn workload
+  [opts]
   (case (:workload opts)
     "bank" (bank/workload opts)
     "set"  (set-workload/workload opts)
@@ -155,35 +162,34 @@
   [opts]
   (println "opts:" opts)
   (println "Time limit set to:" (:time-limit opts))
-  (let [db      (d-db/db)
-        nemesis (d-nemesis/nemesis-package
-                 {:db        db
-                  :nodes     (:nodes opts)
-                  :faults    #{:partition :kill :pause}
-                  :partition {:targets [:majority]}
-                  :pause     {:targets [:all]}
-                  :kill      {:targets [:all]}
-                  :interval  5})
-        wl      (workload opts)]
+  (let [wl (workload opts)]
     (merge tests/noop-test
-           opts
-           {:name    (str "d-engine-" (:workload opts "register"))
-            :os      debian/os
-            :db      db
-            :client  (:client wl)
-            :nemesis (:nemesis nemesis)
-            :checker (:checker wl)
+           {:name      (str "d-engine-" (:workload opts "register"))
+            :ssh       {:private-key-path "/root/.ssh/id_rsa"
+                        :strict-host-key-checking false}
+            :client    (:client wl)
+            :nemesis   (nemesis/partition-random-halves)
+            :checker   (:checker wl)
             :generator (->> (:generator wl)
                             (gen/stagger 1/10)
-                            (gen/nemesis (:generator nemesis))
-                            (gen/time-limit (:time-limit opts)))})))
+                            (gen/nemesis
+                             (cycle [(gen/sleep 10)
+                                     {:type :info, :f :start}
+                                     (gen/sleep 5)
+                                     {:type :info, :f :stop}]))
+                            (gen/time-limit (:time-limit opts)))}
+           opts)))
 
 (def cli-opts
   "Additional command line options."
-  [["-e" "--endpoints ENDPOINTS" "d-engine gRPC endpoints (comma-separated)"
-    :default "http://node1:9081,http://node2:9082,http://node3:9083"
+  [["-c" "--command CMD" "CLI binary path"
+    :default "client-usage-standalone-demo"
     :parse-fn identity
-    :validate [(complement empty?) "Endpoints cannot be empty."]]
+    :validate [(complement empty?) "command cannot be empty."]]
+   ["-e" "--endpoints ENDPOINTS" "d-engine gRPC endpoints (comma-separated)"
+    :default "http://node1:9080,http://node2:9080,http://node3:9080"
+    :parse-fn identity
+    :validate [(complement empty?) "endpoints cannot be empty."]]
    ["-w" "--workload NAME" "Workload to run: register (default), bank, set"
     :default "register"
     :parse-fn identity

--- a/src/jepsen/d_engine/append.clj
+++ b/src/jepsen/d_engine/append.clj
@@ -1,0 +1,97 @@
+(ns jepsen.d_engine.append
+  "Append workload: checks list-append histories for anomalies using Elle.
+   Encodes an ordered sequence as a packed u64 (8 bits x 7 slots, values 1-127).
+   Uses CAS-based atomic append; Elle detects ordering anomalies (G-single, etc.)."
+  (:require [clojure.string :as str]
+            [clojure.java.shell :as shell]
+            [jepsen [client :as client]
+                    [generator :as gen]]
+            [jepsen.tests.cycle.append :as append]
+            [slingshot.slingshot :refer [try+]]))
+
+(def n-keys    3)
+(def n-slots   7)   ; 7 slots x 8 bits = 56 bits, safe within signed long
+(def slot-bits 8)
+
+;; Global counter ensures each appended value is unique per key across the run.
+(def next-val (atom 0))
+
+(defn decode [packed]
+  (->> (range n-slots)
+       (map #(bit-and (bit-shift-right (long packed) (* % slot-bits)) 0xFF))
+       (take-while pos?)
+       vec))
+
+(defn slot-count [packed]
+  (count (decode packed)))
+
+(defn encode-append [packed slot v]
+  (bit-or (long packed) (bit-shift-left (long v) (* slot slot-bits))))
+
+(defn ctl! [cmd endpoints & args]
+  (let [result (apply shell/sh cmd "--endpoints" endpoints (map str args))]
+    (if (zero? (:exit result))
+      (str/trim (:out result))
+      (throw (ex-info "ctl failed" {:err (:err result) :exit (:exit result)})))))
+
+(defn parse-long-safe [s]
+  (when (and s (not (str/blank? s)))
+    (try (Long/parseLong s)
+         (catch NumberFormatException _ nil))))
+
+(defrecord AppendClient [cmd endpoints]
+  client/Client
+
+  (open! [this test node] this)
+
+  (setup! [this test]
+    (doseq [k (range n-keys)]
+      (ctl! cmd endpoints "put" (str k) "0")))
+
+  (invoke! [this test op]
+    (try+
+      (let [[mop-type k v] (first (:value op))]
+        (case mop-type
+          :r
+          (let [packed (or (parse-long-safe (ctl! cmd endpoints "lget" (str k))) 0)]
+            (assoc op :type :ok :value [[:r k (decode packed)]]))
+
+          :append
+          (loop [attempts 0]
+            (if (> attempts 50)
+              (assoc op :type :fail :error :too-many-retries)
+              (let [packed (or (parse-long-safe (ctl! cmd endpoints "lget" (str k))) 0)
+                    slots  (slot-count packed)]
+                (if (>= slots n-slots)
+                  (assoc op :type :fail :error :list-full)
+                  (let [new-packed (encode-append packed slots v)
+                        result     (ctl! cmd endpoints "cas"
+                                         (str k) (str packed) (str new-packed))]
+                    (if (= result "true")
+                      (assoc op :type :ok)
+                      (recur (inc attempts))))))))))
+
+      (catch clojure.lang.ExceptionInfo e
+        (let [err (str (ex-message e) " " (pr-str (ex-data e)))]
+          (cond
+            (re-find #"(?i)cluster unavailable|timeout|deadline exceeded|not leader" err)
+            (assoc op :type :info :error [:unavailable err])
+            :else
+            (assoc op :type :info :error [:unknown err]))))))
+
+  (teardown! [this test])
+  (close! [this test]))
+
+(defn append-op [_ _]
+  {:type :invoke :f :txn
+   :value [[:append (rand-int n-keys) (swap! next-val inc)]]})
+
+(defn read-op [_ _]
+  {:type :invoke :f :txn
+   :value [[:r (rand-int n-keys) nil]]})
+
+(defn workload [opts]
+  {:client    (AppendClient. (:command opts) (:endpoints opts))
+   :checker   (append/checker {:consistency-models [:sequential]
+                               :anomalies          [:G-single]})
+   :generator (gen/mix [append-op read-op])})

--- a/src/jepsen/d_engine/bank.clj
+++ b/src/jepsen/d_engine/bank.clj
@@ -1,22 +1,17 @@
-(ns jepsen.d-engine.bank
+(ns jepsen.d_engine.bank
   "Bank workload: concurrent transfers under faults must preserve total balance.
    Encodes 3 account balances as a single packed u64 for atomic CAS."
-  (:require [clojure.tools.logging :refer [info]]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
+            [clojure.java.shell :as shell]
             [jepsen [checker :as checker]
                     [client :as client]
-                    [control :as c]
                     [generator :as gen]]
-            [jepsen.d-engine.db :as d-db]
             [slingshot.slingshot :refer [try+]]))
 
 (def bank-key     1)
 (def n-accounts   3)
 (def init-balance 1000)
 
-(def ctl-bin (str d-db/dir "/bin/" d-db/ctl-binary))
-
-;; Pack 3 balances (21 bits each) into a single u64.
 (defn pack [a b c]
   (bit-or (bit-shift-left (long a) 42)
           (bit-shift-left (long b) 21)
@@ -29,66 +24,63 @@
 
 (def init-packed (pack init-balance init-balance init-balance))
 
-(defn parse-long-nil [s]
-  (when s
-    (try (Long/parseLong (str/trim s))
+(defn ctl! [cmd endpoints & args]
+  (let [result (apply shell/sh cmd "--endpoints" endpoints (map str args))]
+    (if (zero? (:exit result))
+      (str/trim (:out result))
+      (throw (ex-info "ctl failed" {:err (:err result) :exit (:exit result)})))))
+
+(defn parse-long-safe [s]
+  (when (and s (not (str/blank? s)))
+    (try (Long/parseLong s)
          (catch NumberFormatException _ nil))))
 
-(defrecord BankClient [session node endpoints]
+(defrecord BankClient [cmd endpoints]
   client/Client
 
-  (open! [this test node]
-    (assoc this :session (c/session node) :node node))
+  (open! [this test node] this)
 
   (setup! [this test]
-    (c/with-session node session
-      (c/exec ctl-bin :--endpoints endpoints :put (str bank-key) (str init-packed))))
+    (ctl! cmd endpoints "put" (str bank-key) (str init-packed)))
 
   (invoke! [this test op]
-    (c/with-session node session
-      (try+
-        (case (:f op)
-          :read
-          (let [packed (or (parse-long-nil
-                             (c/exec ctl-bin :--endpoints endpoints :lget (str bank-key)))
-                           init-packed)]
-            (assoc op :type :ok :value (zipmap (range n-accounts) (unpack packed))))
+    (try+
+      (case (:f op)
+        :read
+        (let [packed (or (parse-long-safe (ctl! cmd endpoints "lget" (str bank-key)))
+                         init-packed)]
+          (assoc op :type :ok :value (zipmap (range n-accounts) (unpack packed))))
 
-          :transfer
-          (let [{:keys [from to amount]} (:value op)]
-            (loop [attempts 0]
-              (if (> attempts 50)
-                (assoc op :type :fail :error :too-many-retries)
-                (let [packed   (or (parse-long-nil
-                                     (c/exec ctl-bin :--endpoints endpoints
-                                             :lget (str bank-key)))
-                                   init-packed)
-                      bals     (vec (unpack packed))
-                      from-bal (nth bals from)]
-                  (if (< from-bal amount)
-                    (assoc op :type :fail :error :insufficient-funds)
-                    (let [new-bals   (-> bals (update from - amount) (update to + amount))
-                          new-packed (apply pack new-bals)
-                          result     (str/trim
-                                       (c/exec ctl-bin :--endpoints endpoints
-                                               :cas (str bank-key)
-                                               (str packed) (str new-packed)))]
-                      (if (= result "true")
-                        (assoc op :type :ok)
-                        (recur (inc attempts)))))))))
+        :transfer
+        (let [{:keys [from to amount]} (:value op)]
+          (loop [attempts 0]
+            (if (> attempts 50)
+              (assoc op :type :fail :error :too-many-retries)
+              (let [packed   (or (parse-long-safe (ctl! cmd endpoints "lget" (str bank-key)))
+                                 init-packed)
+                    bals     (vec (unpack packed))
+                    from-bal (nth bals from)]
+                (if (< from-bal amount)
+                  (assoc op :type :fail :error :insufficient-funds)
+                  (let [new-bals   (-> bals (update from - amount) (update to + amount))
+                        new-packed (apply pack new-bals)
+                        swapped    (ctl! cmd endpoints "cas"
+                                        (str bank-key) (str packed) (str new-packed))]
+                    (if (= swapped "true")
+                      (assoc op :type :ok)
+                      (recur (inc attempts))))))))))
 
-        (catch [:type :jepsen.control/nonzero-exit] e
-          (let [err (str (:err e) (:out e))]
-            (cond
-              (re-find #"(?i)cluster unavailable|timeout|deadline exceeded|not leader" err)
-              (assoc op :type :info :error [:unavailable err])
-              :else
-              (assoc op :type :info :error [:unknown err])))))))
+      (catch clojure.lang.ExceptionInfo e
+        (let [err (str (ex-message e) " " (pr-str (ex-data e)))]
+          (cond
+            (re-find #"(?i)cluster unavailable|timeout|deadline exceeded|not leader" err)
+            (assoc op :type :info :error [:unavailable err])
+            :else
+            (assoc op :type :info :error [:unknown err]))))))
 
   (teardown! [this test])
 
-  (close! [this test]
-    (when session (c/disconnect session))))
+  (close! [this test]))
 
 (defn bank-checker []
   (let [expected (* n-accounts init-balance)]
@@ -108,6 +100,6 @@
            :amount (inc (rand-int 5))}})
 
 (defn workload [opts]
-  {:client    (BankClient. nil nil (:endpoints opts))
+  {:client    (BankClient. (:command opts) (:endpoints opts))
    :checker   (bank-checker)
    :generator (gen/mix [t r])})

--- a/src/jepsen/d_engine/bank.clj
+++ b/src/jepsen/d_engine/bank.clj
@@ -1,0 +1,113 @@
+(ns jepsen.d-engine.bank
+  "Bank workload: concurrent transfers under faults must preserve total balance.
+   Encodes 3 account balances as a single packed u64 for atomic CAS."
+  (:require [clojure.tools.logging :refer [info]]
+            [clojure.string :as str]
+            [jepsen [checker :as checker]
+                    [client :as client]
+                    [control :as c]
+                    [generator :as gen]]
+            [jepsen.d-engine.db :as d-db]
+            [slingshot.slingshot :refer [try+]]))
+
+(def bank-key     1)
+(def n-accounts   3)
+(def init-balance 1000)
+
+(def ctl-bin (str d-db/dir "/bin/" d-db/ctl-binary))
+
+;; Pack 3 balances (21 bits each) into a single u64.
+(defn pack [a b c]
+  (bit-or (bit-shift-left (long a) 42)
+          (bit-shift-left (long b) 21)
+          (long c)))
+
+(defn unpack [packed]
+  [(bit-and (bit-shift-right packed 42) 0x1FFFFF)
+   (bit-and (bit-shift-right packed 21) 0x1FFFFF)
+   (bit-and packed 0x1FFFFF)])
+
+(def init-packed (pack init-balance init-balance init-balance))
+
+(defn parse-long-nil [s]
+  (when s
+    (try (Long/parseLong (str/trim s))
+         (catch NumberFormatException _ nil))))
+
+(defrecord BankClient [session node endpoints]
+  client/Client
+
+  (open! [this test node]
+    (assoc this :session (c/session node) :node node))
+
+  (setup! [this test]
+    (c/with-session node session
+      (c/exec ctl-bin :--endpoints endpoints :put (str bank-key) (str init-packed))))
+
+  (invoke! [this test op]
+    (c/with-session node session
+      (try+
+        (case (:f op)
+          :read
+          (let [packed (or (parse-long-nil
+                             (c/exec ctl-bin :--endpoints endpoints :lget (str bank-key)))
+                           init-packed)]
+            (assoc op :type :ok :value (zipmap (range n-accounts) (unpack packed))))
+
+          :transfer
+          (let [{:keys [from to amount]} (:value op)]
+            (loop [attempts 0]
+              (if (> attempts 50)
+                (assoc op :type :fail :error :too-many-retries)
+                (let [packed   (or (parse-long-nil
+                                     (c/exec ctl-bin :--endpoints endpoints
+                                             :lget (str bank-key)))
+                                   init-packed)
+                      bals     (vec (unpack packed))
+                      from-bal (nth bals from)]
+                  (if (< from-bal amount)
+                    (assoc op :type :fail :error :insufficient-funds)
+                    (let [new-bals   (-> bals (update from - amount) (update to + amount))
+                          new-packed (apply pack new-bals)
+                          result     (str/trim
+                                       (c/exec ctl-bin :--endpoints endpoints
+                                               :cas (str bank-key)
+                                               (str packed) (str new-packed)))]
+                      (if (= result "true")
+                        (assoc op :type :ok)
+                        (recur (inc attempts)))))))))
+
+        (catch [:type :jepsen.control/nonzero-exit] e
+          (let [err (str (:err e) (:out e))]
+            (cond
+              (re-find #"(?i)cluster unavailable|timeout|deadline exceeded|not leader" err)
+              (assoc op :type :info :error [:unavailable err])
+              :else
+              (assoc op :type :info :error [:unknown err])))))))
+
+  (teardown! [this test])
+
+  (close! [this test]
+    (when session (c/disconnect session))))
+
+(defn bank-checker []
+  (let [expected (* n-accounts init-balance)]
+    (reify checker/Checker
+      (check [_ test history opts]
+        (let [bad (->> history
+                       (filter #(and (= :ok (:type %)) (= :read (:f %))))
+                       (remove #(= expected (reduce + (vals (:value %))))))]
+          {:valid?    (empty? bad)
+           :bad-reads (take 10 bad)})))))
+
+(defn r [_ _] {:type :invoke :f :read :value nil})
+(defn t [_ _]
+  {:type :invoke :f :transfer
+   :value {:from   (rand-int n-accounts)
+           :to     (rand-int n-accounts)
+           :amount (inc (rand-int 5))}})
+
+(defn workload [opts]
+  {:client    (BankClient. nil nil (:endpoints opts))
+   :checker   (bank-checker)
+   :generator (gen/mix [t r])})

--- a/src/jepsen/d_engine/db.clj
+++ b/src/jepsen/d_engine/db.clj
@@ -11,7 +11,7 @@
 (def binary (or (System/getenv "D_ENGINE_BINARY")
                 "three-nodes-embedded-linux-amd64"))
 (def ctl-binary (or (System/getenv "D_ENGINE_CTL_BINARY")
-                    "dengine_ctl-linux-amd64"))
+                    "client-usage-standalone-demo-linux-amd64"))
 (def s3-base-url (System/getenv "S3_BASE_URL"))
 (def logfile (str dir "/d-engine.log"))
 (def pidfile (str dir "/d-engine.pid"))

--- a/src/jepsen/d_engine/db.clj
+++ b/src/jepsen/d_engine/db.clj
@@ -1,6 +1,6 @@
 (ns jepsen.d_engine.db
   "Database lifecycle for d-engine Docker nodes.
-  setup!/teardown! are no-ops — Docker handles installation and config.
+  teardown! kills demo; setup! restarts it so the cluster reforms before each test.
   kill!/start!/pause!/resume! operate via SSH on the running demo process."
   (:require [clojure.tools.logging :refer [info warn]]
             [jepsen [control :as c]
@@ -40,13 +40,15 @@
 (defrecord DB []
   db/DB
   (setup! [_ test node]
-    ; Docker already started demo with correct config — nothing to install.
-    (info node "d-engine running in Docker, skipping setup"))
+    ; Demo is running from Docker startup — cluster lifecycle is managed by
+    ; restart-stack (docker compose down/up), not by Jepsen setup/teardown.
+    (info node "d-engine already running (Docker mode), skipping setup"))
 
   (teardown! [_ test node]
-    ; Leave data dirs intact (mounted from host). Just stop the process.
-    (info node "tearing down d-engine")
-    (kill!))
+    ; Do NOT kill demo here. teardown! runs before setup! at test start,
+    ; so killing here would leave the cluster dead for the entire test.
+    ; restart-stack resets state between test runs.
+    (info node "d-engine teardown skipped (Docker mode)"))
 
   db/LogFiles
   (log-files [_ test node]

--- a/src/jepsen/d_engine/db.clj
+++ b/src/jepsen/d_engine/db.clj
@@ -1,151 +1,63 @@
-(ns jepsen.d-engine.db
-  "Database setup and automation for d-engine"
+(ns jepsen.d_engine.db
+  "Database lifecycle for d-engine Docker nodes.
+  setup!/teardown! are no-ops — Docker handles installation and config.
+  kill!/start!/pause!/resume! operate via SSH on the running demo process."
   (:require [clojure.tools.logging :refer [info warn]]
-            [clojure.string :as str]
             [jepsen [control :as c]
-             [core :as jepsen]
-             [db :as db]]
+                    [db :as db]]
             [jepsen.control.util :as cu]))
 
-(def dir "/opt/d-engine")
-(def binary (or (System/getenv "D_ENGINE_BINARY")
-                "three-nodes-embedded-linux-amd64"))
-(def ctl-binary (or (System/getenv "D_ENGINE_CTL_BINARY")
-                    "client-usage-standalone-demo-linux-amd64"))
-(def s3-base-url (System/getenv "S3_BASE_URL"))
-(def logfile (str dir "/d-engine.log"))
-(def pidfile (str dir "/d-engine.pid"))
+(def binary  "demo")
+(def logfile "/app/logs/d-engine-jepsen.log")
 
-(defn node-id
-  "Maps node names to numeric IDs (node1->1, node2->2, node3->3)"
-  [node]
+(defn node-id [node]
   (case node
-    "node1" 1
-    "node2" 2
-    "node3" 3
+    "node1" 1 "node2" 2 "node3" 3
     (throw (ex-info "Unknown node" {:node node}))))
 
-(defn client-port
-  "Client port for a given node"
-  [node]
-  (+ 8080 (node-id node)))
-
-(defn raft-port
-  "Raft port for a given node"
-  [node]
-  (+ 9080 (node-id node)))
-
-(defn health-port
-  "Health check port for a given node"
-  [node]
-  (+ 10000 (node-id node)))
-
-(defn data-dir
-  "Data directory for this node"
-  [node]
-  (str dir "/db/" (node-id node)))
-
-(defn config-path
-  "Config file path for this node"
-  [node]
-  (str dir "/config/n" (node-id node) ".toml"))
-
-(defn wipe!
-  "Wipes data files on the current node"
-  [test node]
-  (c/su
-   (c/exec :rm :-rf (data-dir node))
-   (c/exec :rm :-rf logfile)))
+(defn kill!
+  "Kills the demo process on the current node via SIGKILL."
+  []
+  (c/su (cu/grepkill! binary)))
 
 (defn start!
-  "Starts d-engine on the given node"
-  [test node]
-  (c/su
-   (cu/start-daemon!
-    {:logfile logfile
-     :pidfile pidfile
-     :chdir   dir}
-    (str dir "/bin/" binary)
-    :--port (client-port node)
-    :--health-port (health-port node)
-    :--config-path (config-path node))))
-
-(defn kill!
-  "Kills d-engine process"
-  []
-  (c/su (cu/stop-daemon! binary pidfile)))
+  "Restarts the demo binary. Env vars are reconstructed from node identity
+  since SSH sessions don't inherit docker-compose environment."
+  [node]
+  (let [id    (node-id node)
+        conf  (str "config/n" id)
+        log   (str "./logs/" id)
+        mport (+ 8080 id)]
+    (c/su
+      (c/exec :bash :-c
+        (str "nohup env"
+             " CONFIG_PATH=" conf
+             " LOG_DIR=" log
+             " METRICS_PORT=" mport
+             " RUST_LOG=demo=debug,d_engine=debug,hyper=warn,sled=warn"
+             " /usr/local/bin/demo >> " logfile " 2>&1 &")))))
 
 (defrecord DB []
   db/DB
-  (setup! [db test node]
-    (info node "setting up d-engine")
-    (c/su
-      ; Create directory structure
-     (c/exec :mkdir :-p dir)
-     (c/exec :mkdir :-p (str dir "/bin"))
-     (c/exec :mkdir :-p (str dir "/config"))
-     (c/exec :mkdir :-p (data-dir node))
+  (setup! [_ test node]
+    ; Docker already started demo with correct config — nothing to install.
+    (info node "d-engine running in Docker, skipping setup"))
 
-      ; Check if binaries exist (mounted from host), otherwise download from S3
-     (when s3-base-url
-       (when-not (cu/exists? (str dir "/bin/" binary))
-         (info node "downloading binary from S3")
-         (c/exec :curl :-L :-o (str dir "/bin/" binary)
-                 (str s3-base-url "/" binary))
-         (c/exec :chmod :+x (str dir "/bin/" binary)))
-
-       (when-not (cu/exists? (str dir "/bin/" ctl-binary))
-         (info node "downloading dengine_ctl from S3")
-         (c/exec :curl :-L :-o (str dir "/bin/" ctl-binary)
-                 (str s3-base-url "/" ctl-binary))
-         (c/exec :chmod :+x (str dir "/bin/" ctl-binary))))
-
-      ; Create config file dynamically
-     (c/exec :echo
-             (str "[cluster]\n"
-                  "node_id = " (node-id node) "\n"
-                  "listen_address = \"0.0.0.0:" (raft-port node) "\"\n"
-                  "initial_cluster = [\n"
-                  "    { id = 1, address = \"node1:" (raft-port "node1") "\", role = 1, status = 2 },\n"
-                  "    { id = 2, address = \"node2:" (raft-port "node2") "\", role = 1, status = 2 },\n"
-                  "    { id = 3, address = \"node3:" (raft-port "node3") "\", role = 1, status = 2 },\n"
-                  "]\n"
-                  "db_root_dir = \"" (data-dir node) "\"\n\n"
-                  "[raft.snapshot]\n"
-                  "enable = false\n")
-             :> (config-path node)))
-
-    (db/start! db test node)
-
-    ; Wait for node to be ready
-    (Thread/sleep 5000)
-    (info node "d-engine started"))
-
-  (teardown! [db test node]
+  (teardown! [_ test node]
+    ; Leave data dirs intact (mounted from host). Just stop the process.
     (info node "tearing down d-engine")
-    (kill!)
-    (c/su
-      ; Only delete data and config, preserve /bin (which is mounted from host)
-      (c/exec :rm :-rf (data-dir node))
-      (c/exec :rm :-rf (str dir "/config"))
-      (c/exec :rm :-f logfile pidfile)))
+    (kill!))
 
   db/LogFiles
   (log-files [_ test node]
-    {logfile "d-engine.log"})
+    {logfile "d-engine-jepsen.log"})
 
   db/Process
-  (start! [_ test node]
-    (start! test node))
-
-  (kill! [_ test node]
-    (kill!))
+  (start! [_ test node] (start! node))
+  (kill!  [_ test node] (kill!))
 
   db/Pause
-  (pause!  [_ test node] (c/su (cu/grepkill! :stop binary)))
-  (resume! [_ test node] (c/su (cu/grepkill! :cont binary))))
+  (pause!  [_ test node] (c/su (cu/grepkill! :stop  binary)))
+  (resume! [_ test node] (c/su (cu/grepkill! :cont  binary))))
 
-(defn db
-  "Creates a new d-engine DB"
-  []
-  (DB.))
+(defn db [] (DB.))

--- a/src/jepsen/d_engine/nemesis.clj
+++ b/src/jepsen/d_engine/nemesis.clj
@@ -1,4 +1,4 @@
-(ns jepsen.d-engine.nemesis
+(ns jepsen.d_engine.nemesis
   "Nemesis implementations for d-engine testing"
   (:require [clojure.tools.logging :refer [info]]
             [jepsen.nemesis :as nemesis]
@@ -6,18 +6,20 @@
             [jepsen.generator :as gen]))
 
 (defn nemesis-package
-  "Constructs a nemesis and generators for d-engine using Jepsen's combined nemesis framework.
+  "Constructs a nemesis package for d-engine, instantiating only the requested fault types.
 
-  Options:
-    :faults    - Set of fault types to inject (e.g., #{:partition :kill :pause})
-    :interval  - Time between nemesis operations (seconds)
-    :partition - Partition configuration (e.g., {:targets [:majority]})
-    :pause     - Process pause configuration (e.g., {:targets [:all]})
-    :kill      - Process kill configuration (e.g., {:targets [:all]})"
+  Uses nc/nemesis-packages selectively to avoid unconditional setup! of all nemeses
+  (clock nemesis installs build-essential, bitflip downloads a binary — both fail in
+  our Docker environment which has no apt lists and no internet access from nodes).
+
+  Supported faults: :partition, :kill, :pause"
   [opts]
-  (let [opts (update opts :faults set)]
-    (-> (nc/nemesis-packages opts)
-        nc/compose-packages)))
+  ; kill and pause are both handled by nc/db-package in Jepsen 0.3.x
+  (let [faults (set (:faults opts))
+        pkgs   (cond-> []
+                 (:partition faults)              (conj (nc/partition-package opts))
+                 (some faults #{:kill :pause})    (conj (nc/db-package opts)))]
+    (nc/compose-packages pkgs)))
 
 (defn full-generator
   "Generator for mixed fault injection.

--- a/src/jepsen/d_engine/set.clj
+++ b/src/jepsen/d_engine/set.clj
@@ -1,85 +1,73 @@
-(ns jepsen.d-engine.set
+(ns jepsen.d_engine.set
   "Set workload: every acknowledged add must survive faults and appear in reads.
    Encodes a set of integers 0-62 as a u64 bitmask; CAS ensures atomic updates."
-  (:require [clojure.tools.logging :refer [info]]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
+            [clojure.java.shell :as shell]
             [jepsen [checker :as checker]
                     [client :as client]
-                    [control :as c]
                     [generator :as gen]]
-            [jepsen.d-engine.db :as d-db]
             [slingshot.slingshot :refer [try+]]))
 
 (def set-key 42)
 
-(def ctl-bin (str d-db/dir "/bin/" d-db/ctl-binary))
+(defn ctl! [cmd endpoints & args]
+  (let [result (apply shell/sh cmd "--endpoints" endpoints (map str args))]
+    (if (zero? (:exit result))
+      (str/trim (:out result))
+      (throw (ex-info "ctl failed" {:err (:err result) :exit (:exit result)})))))
 
-(defn parse-long-nil [s]
-  (when s
-    (try (Long/parseLong (str/trim s))
+(defn parse-long-safe [s]
+  (when (and s (not (str/blank? s)))
+    (try (Long/parseLong s)
          (catch NumberFormatException _ nil))))
 
-(defn decode-set
-  "Decode a u64 bitmask into a set of present element indices."
-  [packed]
+(defn decode-set [packed]
   (->> (range 63)
        (filter #(not= 0 (bit-and packed (bit-shift-left 1 %))))
        set))
 
-(defrecord SetClient [session node endpoints]
+(defrecord SetClient [cmd endpoints]
   client/Client
 
-  (open! [this test node]
-    (assoc this :session (c/session node) :node node))
+  (open! [this test node] this)
 
   (setup! [this test]
-    (c/with-session node session
-      (c/exec ctl-bin :--endpoints endpoints :put (str set-key) "0")))
+    (ctl! cmd endpoints "put" (str set-key) "0"))
 
   (invoke! [this test op]
-    (c/with-session node session
-      (try+
-        (case (:f op)
-          :add
-          (loop [attempts 0]
-            (if (> attempts 50)
-              (assoc op :type :fail :error :too-many-retries)
-              (let [current  (or (parse-long-nil
-                                   (c/exec ctl-bin :--endpoints endpoints
-                                           :lget (str set-key)))
-                                 0)
-                    new-val  (bit-or current (bit-shift-left 1 (long (:value op))))
-                    result   (str/trim
-                               (c/exec ctl-bin :--endpoints endpoints
-                                       :cas (str set-key)
-                                       (str current) (str new-val)))]
-                (if (= result "true")
-                  (assoc op :type :ok)
-                  (recur (inc attempts))))))
+    (try+
+      (case (:f op)
+        :add
+        (loop [attempts 0]
+          (if (> attempts 50)
+            (assoc op :type :fail :error :too-many-retries)
+            (let [current (or (parse-long-safe (ctl! cmd endpoints "lget" (str set-key))) 0)
+                  new-val (bit-or current (bit-shift-left 1 (long (:value op))))
+                  result  (ctl! cmd endpoints "cas" (str set-key) (str current) (str new-val))]
+              (if (= result "true")
+                (assoc op :type :ok)
+                (recur (inc attempts))))))
 
-          :read
-          (let [packed (or (parse-long-nil
-                             (c/exec ctl-bin :--endpoints endpoints :lget (str set-key)))
-                           0)]
-            (assoc op :type :ok :value (decode-set packed))))
+        :read
+        (let [packed (or (parse-long-safe (ctl! cmd endpoints "lget" (str set-key))) 0)]
+          (assoc op :type :ok :value (decode-set packed))))
 
-        (catch [:type :jepsen.control/nonzero-exit] e
-          (let [err (str (:err e) (:out e))]
-            (cond
-              (re-find #"(?i)cluster unavailable|timeout|deadline exceeded|not leader" err)
-              (assoc op :type :fail :error [:unavailable err])
-              :else
-              (assoc op :type :fail :error [:unknown err])))))))
+      (catch clojure.lang.ExceptionInfo e
+        (let [err (str (ex-message e) " " (pr-str (ex-data e)))]
+          (cond
+            (re-find #"(?i)cluster unavailable|timeout|deadline exceeded|not leader" err)
+            (assoc op :type :fail :error [:unavailable err])
+            :else
+            (assoc op :type :fail :error [:unknown err]))))))
 
   (teardown! [this test])
 
-  (close! [this test]
-    (when session (c/disconnect session))))
+  (close! [this test]))
 
 (defn add-op [_ _] {:type :invoke :f :add :value (rand-int 30)})
 (defn read-op [_ _] {:type :invoke :f :read :value nil})
 
 (defn workload [opts]
-  {:client    (SetClient. nil nil (:endpoints opts))
+  {:client    (SetClient. (:command opts) (:endpoints opts))
    :checker   (checker/set-full)
    :generator (gen/mix [add-op read-op])})

--- a/src/jepsen/d_engine/set.clj
+++ b/src/jepsen/d_engine/set.clj
@@ -1,0 +1,85 @@
+(ns jepsen.d-engine.set
+  "Set workload: every acknowledged add must survive faults and appear in reads.
+   Encodes a set of integers 0-62 as a u64 bitmask; CAS ensures atomic updates."
+  (:require [clojure.tools.logging :refer [info]]
+            [clojure.string :as str]
+            [jepsen [checker :as checker]
+                    [client :as client]
+                    [control :as c]
+                    [generator :as gen]]
+            [jepsen.d-engine.db :as d-db]
+            [slingshot.slingshot :refer [try+]]))
+
+(def set-key 42)
+
+(def ctl-bin (str d-db/dir "/bin/" d-db/ctl-binary))
+
+(defn parse-long-nil [s]
+  (when s
+    (try (Long/parseLong (str/trim s))
+         (catch NumberFormatException _ nil))))
+
+(defn decode-set
+  "Decode a u64 bitmask into a set of present element indices."
+  [packed]
+  (->> (range 63)
+       (filter #(not= 0 (bit-and packed (bit-shift-left 1 %))))
+       set))
+
+(defrecord SetClient [session node endpoints]
+  client/Client
+
+  (open! [this test node]
+    (assoc this :session (c/session node) :node node))
+
+  (setup! [this test]
+    (c/with-session node session
+      (c/exec ctl-bin :--endpoints endpoints :put (str set-key) "0")))
+
+  (invoke! [this test op]
+    (c/with-session node session
+      (try+
+        (case (:f op)
+          :add
+          (loop [attempts 0]
+            (if (> attempts 50)
+              (assoc op :type :fail :error :too-many-retries)
+              (let [current  (or (parse-long-nil
+                                   (c/exec ctl-bin :--endpoints endpoints
+                                           :lget (str set-key)))
+                                 0)
+                    new-val  (bit-or current (bit-shift-left 1 (long (:value op))))
+                    result   (str/trim
+                               (c/exec ctl-bin :--endpoints endpoints
+                                       :cas (str set-key)
+                                       (str current) (str new-val)))]
+                (if (= result "true")
+                  (assoc op :type :ok)
+                  (recur (inc attempts))))))
+
+          :read
+          (let [packed (or (parse-long-nil
+                             (c/exec ctl-bin :--endpoints endpoints :lget (str set-key)))
+                           0)]
+            (assoc op :type :ok :value (decode-set packed))))
+
+        (catch [:type :jepsen.control/nonzero-exit] e
+          (let [err (str (:err e) (:out e))]
+            (cond
+              (re-find #"(?i)cluster unavailable|timeout|deadline exceeded|not leader" err)
+              (assoc op :type :fail :error [:unavailable err])
+              :else
+              (assoc op :type :fail :error [:unknown err])))))))
+
+  (teardown! [this test])
+
+  (close! [this test]
+    (when session (c/disconnect session))))
+
+(defn add-op [_ _] {:type :invoke :f :add :value (rand-int 30)})
+(defn read-op [_ _] {:type :invoke :f :read :value nil})
+
+(defn workload [opts]
+  {:client    (SetClient. nil nil (:endpoints opts))
+   :checker   (checker/set-full)
+   :generator (gen/mix [add-op read-op])})


### PR DESCRIPTION
## Summary

- Add bank, set, append workloads (4 total: register/bank/set/append)
- Wire nemesis-package with configurable faults (partition, kill, pause) via --faults CLI
- Fix Docker cluster setup: Jepsen-specific config with container IPs for Raft peer discovery
- Add test-all target; fix restart-stack DB cleanup path (false linearizability violations)

## Workloads

| Workload | Checker | Encoding |
|----------|---------|----------|
| register | Knossos linearizable | CAS u64 |
| bank | custom total-balance | packed u64 (3 accounts × 21 bits) |
| set | jepsen set-full | bitmask u64 (63 elements) |
| append | Elle sequential | packed u64 (8 bits × 7 slots) |

## Verified

- `make test-all` (partition faults): all 4 workloads ✅
- `make test FAULTS=kill WORKLOAD=register` ✅
- `make test FAULTS=pause WORKLOAD=register` ✅

## Known Limitations

- Client uses CLI binary + shell/sh (not native gRPC); timeout relies on d-engine internal config.
  Proper Clojure gRPC client is planned as follow-up (#2).
- Snapshot testing not covered (snapshot disabled in config).
- Test duration is 60s; extended soak tests (6+ hours) are out of scope for this PR.
