### PR TITLE
feat #4: increase Jepsen test coverage with multi-endpoint failover and combined faults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,20 @@ test-all:
 	$(MAKE) test WORKLOAD=append
 	@echo "=== All workloads passed ✅ ==="
 
+# High-concurrency stress test (RATE=200, 10 min).
+# Surfaces low-probability linearizability violations that 60s/rate=10 cannot.
+#   make test-stress
+#   make test-stress WORKLOAD=bank
+test-stress:
+	$(MAKE) test WORKLOAD=$(WORKLOAD) FAULTS=kill,partition RATE=200 TIME_LIMIT=600
+
+# Combined fault test (kill+partition, 5 min, moderate rate).
+# Validates client failover under simultaneous process kill and network partition.
+#   make test-combined
+#   make test-combined WORKLOAD=bank
+test-combined:
+	$(MAKE) test WORKLOAD=$(WORKLOAD) FAULTS=kill,partition RATE=50 TIME_LIMIT=300
+
 # Set up SSH agent inside container
 ssh-setup:
 	@echo "Configuring SSH keys..."

--- a/src/jepsen/d_engine.clj
+++ b/src/jepsen/d_engine.clj
@@ -33,34 +33,32 @@
 (defn r [_ _] {:type :invoke, :f :read,  :value nil})
 (defn w [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
 
-(defrecord RegisterClient [endpoints ch]
+(defrecord RegisterClient [endpoints channels]
   client/Client
   (open! [this test node]
-    (assoc this :ch (grpc/open-channel (grpc/find-endpoint endpoints node))))
+    (assoc this :channels (grpc/open-all-channels endpoints)))
   (setup!    [_ _])
   (teardown! [_ _])
   (close! [this _]
-    (when ch (grpc/close-channel ch)))
+    (when channels (grpc/close-all-channels channels)))
   (invoke! [_ test op]
     (let [[k v] (:value op)]
       (case (:f op)
         :read
-        (let [res (grpc/lget ch k)]
+        (let [res (grpc/lget channels k)]
           (case (:type res)
-            :ok   (if-let [val (:value res)]
-                    (assoc op :type :ok :value (independent/tuple k val))
-                    (assoc op :type :fail :error :not-found))
+            :ok   (assoc op :type :ok :value (independent/tuple k (:value res)))
             :info (assoc op :type :fail :error (:error res))
             :fail (assoc op :type :fail :error (:error res))))
         :write
-        (let [res (grpc/put! ch k v)]
+        (let [res (grpc/put! channels k v)]
           (case (:type res)
             :ok   (assoc op :type :ok)
             :info (assoc op :type :info :error (:error res))
             :fail (assoc op :type :fail :error (:error res))))))))
 
 (defn register-workload [opts]
-  {:client  (RegisterClient. (:endpoints opts) nil)
+  {:client  (RegisterClient. (:endpoints opts) nil) ; channels populated in open!
    :checker (independent/checker
               (checker/compose
                {:linear   (checker/linearizable {:model     (model/cas-register)

--- a/src/jepsen/d_engine/append.clj
+++ b/src/jepsen/d_engine/append.clj
@@ -26,21 +26,21 @@
 (defn encode-append [packed slot v]
   (bit-or (long packed) (bit-shift-left (long v) (* slot slot-bits))))
 
-(defrecord AppendClient [endpoints ch]
+(defrecord AppendClient [endpoints channels]
   client/Client
 
   (open! [this test node]
-    (assoc this :ch (grpc/open-channel (grpc/find-endpoint endpoints node))))
+    (assoc this :channels (grpc/open-all-channels endpoints)))
 
   (setup! [this test]
     (doseq [k (range n-keys)]
-      (grpc/put! ch k 0)))
+      (grpc/put! channels k 0)))
 
   (invoke! [this test op]
     (let [[mop-type k v] (first (:value op))]
       (case mop-type
         :r
-        (let [res (grpc/lget ch k)]
+        (let [res (grpc/lget channels k)]
           (case (:type res)
             :ok   (assoc op :type :ok :value [[:r k (decode (or (:value res) 0))]])
             :info (assoc op :type :info :error (:error res))
@@ -50,7 +50,7 @@
         (loop [attempts 0]
           (if (> attempts 50)
             (assoc op :type :fail :error :too-many-retries)
-            (let [res (grpc/lget ch k)]
+            (let [res (grpc/lget channels k)]
               (case (:type res)
                 :info (assoc op :type :info :error (:error res))
                 :fail (assoc op :type :fail :error (:error res))
@@ -60,7 +60,7 @@
                   (if (>= slots n-slots)
                     (assoc op :type :fail :error :list-full)
                     (let [new-packed (encode-append packed slots v)
-                          cas-res    (grpc/cas! ch k packed new-packed)]
+                          cas-res    (grpc/cas! channels k packed new-packed)]
                       (case (:type cas-res)
                         :ok   (if (:swapped cas-res)
                                 (assoc op :type :ok)
@@ -71,7 +71,7 @@
   (teardown! [this test])
 
   (close! [this test]
-    (when ch (grpc/close-channel ch))))
+    (when channels (grpc/close-all-channels channels))))
 
 (defn append-op [_ _]
   {:type :invoke :f :txn
@@ -82,7 +82,7 @@
    :value [[:r (rand-int n-keys) nil]]})
 
 (defn workload [opts]
-  {:client    (AppendClient. (:endpoints opts) nil)
+  {:client    (AppendClient. (:endpoints opts) nil) ; channels populated in open!
    :checker   (append/checker {:consistency-models [:sequential]
                                :anomalies          [:G-single]})
    :generator (gen/mix [append-op read-op])})

--- a/src/jepsen/d_engine/bank.clj
+++ b/src/jepsen/d_engine/bank.clj
@@ -22,19 +22,19 @@
 
 (def init-packed (pack init-balance init-balance init-balance))
 
-(defrecord BankClient [endpoints ch]
+(defrecord BankClient [endpoints channels]
   client/Client
 
   (open! [this test node]
-    (assoc this :ch (grpc/open-channel (grpc/find-endpoint endpoints node))))
+    (assoc this :channels (grpc/open-all-channels endpoints)))
 
   (setup! [this test]
-    (grpc/put! ch bank-key init-packed))
+    (grpc/put! channels bank-key init-packed))
 
   (invoke! [this test op]
     (case (:f op)
       :read
-      (let [res (grpc/lget ch bank-key)]
+      (let [res (grpc/lget channels bank-key)]
         (case (:type res)
           :ok   (let [packed (or (:value res) init-packed)]
                   (assoc op :type :ok :value (zipmap (range n-accounts) (unpack packed))))
@@ -46,7 +46,7 @@
         (loop [attempts 0]
           (if (> attempts 50)
             (assoc op :type :fail :error :too-many-retries)
-            (let [res (grpc/lget ch bank-key)]
+            (let [res (grpc/lget channels bank-key)]
               (case (:type res)
                 :info (assoc op :type :info :error (:error res))
                 :fail (assoc op :type :fail :error (:error res))
@@ -58,7 +58,7 @@
                     (assoc op :type :fail :error :insufficient-funds)
                     (let [new-bals   (-> bals (update from - amount) (update to + amount))
                           new-packed (apply pack new-bals)
-                          cas-res    (grpc/cas! ch bank-key packed new-packed)]
+                          cas-res    (grpc/cas! channels bank-key packed new-packed)]
                       (case (:type cas-res)
                         :ok   (if (:swapped cas-res)
                                 (assoc op :type :ok)
@@ -69,7 +69,7 @@
   (teardown! [this test])
 
   (close! [this test]
-    (when ch (grpc/close-channel ch))))
+    (when channels (grpc/close-all-channels channels))))
 
 (defn bank-checker []
   (let [expected (* n-accounts init-balance)]
@@ -89,6 +89,6 @@
            :amount (inc (rand-int 5))}})
 
 (defn workload [opts]
-  {:client    (BankClient. (:endpoints opts) nil)
+  {:client    (BankClient. (:endpoints opts) nil) ; channels populated in open!
    :checker   (bank-checker)
    :generator (gen/mix [t r])})

--- a/src/jepsen/d_engine/client.clj
+++ b/src/jepsen/d_engine/client.clj
@@ -55,8 +55,22 @@
         (.usePlaintext)
         (.build))))
 
+(defn open-all-channels
+  "Opens one channel per endpoint. Returns a vector of ManagedChannels.
+   On node kill, application-level failover (with-failover) routes around the dead node."
+  [endpoints-str]
+  (let [clean #(-> % str/trim
+                   (str/replace #"^https?://" "")
+                   (str/replace #"/$" ""))
+        eps   (->> (str/split endpoints-str #",") (map clean))]
+    (mapv open-channel eps)))
+
 (defn close-channel [^ManagedChannel ch]
   (-> ch (.shutdown) (.awaitTermination 5 TimeUnit/SECONDS)))
+
+(defn close-all-channels [channels]
+  (doseq [^ManagedChannel ch channels]
+    (close-channel ch)))
 
 ;; ── Error classification ─────────────────────────────────────────────────────
 
@@ -83,97 +97,116 @@
   (-> (RaftClientServiceGrpc/newBlockingStub ch)
       (.withDeadlineAfter deadline-secs TimeUnit/SECONDS)))
 
+;; ── Failover ─────────────────────────────────────────────────────────────────
+
+(defn- with-failover
+  "Tries op (fn [ch]) on each channel in shuffled order until a non-:info result.
+   Shuffling spreads load across nodes; on node kill the dead channel is skipped
+   after one timeout, and surviving nodes answer the operation."
+  [channels op]
+  (loop [[ch & remaining] (shuffle (vec channels))]
+    (let [result (op ch)]
+      (if (and (= :info (:type result)) (seq remaining))
+        (recur remaining)
+        result))))
+
 ;; ── Public API ───────────────────────────────────────────────────────────────
 
 (defn put!
   "Write key→value. Returns :ok on success, :info if outcome unknown, :fail on definite error."
-  [^ManagedChannel ch key val]
-  (try
-    (let [insert  (-> (ClientApi$WriteCommand$Insert/newBuilder)
-                      (.setKey (encode-u64 key))
-                      (.setValue (encode-u64 val))
-                      (.build))
-          cmd     (-> (ClientApi$WriteCommand/newBuilder)
-                      (.setInsert insert)
-                      (.build))
-          req     (-> (ClientApi$ClientWriteRequest/newBuilder)
-                      (.setClientId client-id)
-                      (.setCommand cmd)
-                      (.build))
-          resp    (.handleClientWrite (blocking-stub ch) req)
-          code    (.getError resp)]
-      (if (= code Error$ErrorCode/SUCCESS)
-        {:type :ok}
-        {:type (classify-error-code code) :error (str code)}))
-    (catch StatusRuntimeException e
-      (if (= (.getCode (.getStatus e)) io.grpc.Status$Code/DEADLINE_EXCEEDED)
-        {:type :info :error :deadline-exceeded}
-        {:type :info :error (str (.getStatus e))}))
-    (catch Exception e
-      {:type :info :error (str e)})))
+  [channels key val]
+  (with-failover channels
+    (fn [^ManagedChannel ch]
+      (try
+        (let [insert  (-> (ClientApi$WriteCommand$Insert/newBuilder)
+                          (.setKey (encode-u64 key))
+                          (.setValue (encode-u64 val))
+                          (.build))
+              cmd     (-> (ClientApi$WriteCommand/newBuilder)
+                          (.setInsert insert)
+                          (.build))
+              req     (-> (ClientApi$ClientWriteRequest/newBuilder)
+                          (.setClientId client-id)
+                          (.setCommand cmd)
+                          (.build))
+              resp    (.handleClientWrite (blocking-stub ch) req)
+              code    (.getError resp)]
+          (if (= code Error$ErrorCode/SUCCESS)
+            {:type :ok}
+            {:type (classify-error-code code) :error (str code)}))
+        (catch StatusRuntimeException e
+          (if (= (.getCode (.getStatus e)) io.grpc.Status$Code/DEADLINE_EXCEEDED)
+            {:type :info :error :deadline-exceeded}
+            {:type :info :error (str (.getStatus e))}))
+        (catch Exception e
+          {:type :info :error (str e)})))))
 
 (defn lget
   "Linearizable read of key. Returns {:type :ok :value v} or nil-value on KEY_NOT_EXIST,
    :info if outcome unknown, :fail on definite error."
-  [^ManagedChannel ch key]
-  (try
-    (let [req  (-> (ClientApi$ClientReadRequest/newBuilder)
-                   (.setClientId client-id)
-                   (.addKeys (encode-u64 key))
-                   (.setConsistencyPolicy ClientApi$ReadConsistencyPolicy/READ_CONSISTENCY_POLICY_LINEARIZABLE_READ)
-                   (.build))
-          resp (.handleClientRead (blocking-stub ch) req)
-          code (.getError resp)]
-      (cond
-        (= code Error$ErrorCode/SUCCESS)
-        (let [results (-> resp .getReadData .getResultsList)]
-          {:type :ok :value (when (seq results)
-                              (decode-u64 (.getValue (first results))))})
+  [channels key]
+  (with-failover channels
+    (fn [^ManagedChannel ch]
+      (try
+        (let [req  (-> (ClientApi$ClientReadRequest/newBuilder)
+                       (.setClientId client-id)
+                       (.addKeys (encode-u64 key))
+                       (.setConsistencyPolicy ClientApi$ReadConsistencyPolicy/READ_CONSISTENCY_POLICY_LINEARIZABLE_READ)
+                       (.build))
+              resp (.handleClientRead (blocking-stub ch) req)
+              code (.getError resp)]
+          (cond
+            (= code Error$ErrorCode/SUCCESS)
+            (let [results (-> resp .getReadData .getResultsList)]
+              {:type :ok :value (when (seq results)
+                                  (decode-u64 (.getValue (first results))))})
 
-        (= code Error$ErrorCode/KEY_NOT_EXIST)
-        {:type :ok :value nil}
+            (= code Error$ErrorCode/KEY_NOT_EXIST)
+            {:type :ok :value nil}
 
-        :else
-        {:type (classify-error-code code) :error (str code)}))
-    (catch StatusRuntimeException e
-      (if (= (.getCode (.getStatus e)) io.grpc.Status$Code/DEADLINE_EXCEEDED)
-        {:type :info :error :deadline-exceeded}
-        {:type :info :error (str (.getStatus e))}))
-    (catch Exception e
-      {:type :info :error (str e)})))
+            :else
+            {:type (classify-error-code code) :error (str code)}))
+        (catch StatusRuntimeException e
+          (if (= (.getCode (.getStatus e)) io.grpc.Status$Code/DEADLINE_EXCEEDED)
+            {:type :info :error :deadline-exceeded}
+            {:type :info :error (str (.getStatus e))}))
+        (catch Exception e
+          {:type :info :error (str e)})))))
 
 (defn cas!
   "Atomic compare-and-swap. Returns {:type :ok :swapped true/false},
    :info if outcome unknown, :fail on definite error."
-  [^ManagedChannel ch key expected new-val]
-  (try
-    (let [cas  (-> (ClientApi$WriteCommand$CompareAndSwap/newBuilder)
-                   (.setKey (encode-u64 key))
-                   (.setExpectedValue (encode-u64 expected))
-                   (.setNewValue (encode-u64 new-val))
-                   (.build))
-          cmd  (-> (ClientApi$WriteCommand/newBuilder)
-                   (.setCompareAndSwap cas)
-                   (.build))
-          req  (-> (ClientApi$ClientWriteRequest/newBuilder)
-                   (.setClientId client-id)
-                   (.setCommand cmd)
-                   (.build))
-          resp (.handleClientWrite (blocking-stub ch) req)
-          code (.getError resp)]
-      (cond
-        (= code Error$ErrorCode/SUCCESS)
-        {:type :ok :swapped (-> resp .getWriteResult .getSucceeded)}
+  [channels key expected new-val]
+  (with-failover channels
+    (fn [^ManagedChannel ch]
+      (try
+        (let [cas  (-> (ClientApi$WriteCommand$CompareAndSwap/newBuilder)
+                       (.setKey (encode-u64 key))
+                       (.setExpectedValue (encode-u64 expected))
+                       (.setNewValue (encode-u64 new-val))
+                       (.build))
+              cmd  (-> (ClientApi$WriteCommand/newBuilder)
+                       (.setCompareAndSwap cas)
+                       (.build))
+              req  (-> (ClientApi$ClientWriteRequest/newBuilder)
+                       (.setClientId client-id)
+                       (.setCommand cmd)
+                       (.build))
+              resp (.handleClientWrite (blocking-stub ch) req)
+              code (.getError resp)]
+          (cond
+            (= code Error$ErrorCode/SUCCESS)
+            {:type :ok :swapped (-> resp .getWriteResult .getSucceeded)}
 
-        ;; CAS failure (expected mismatch) is a definite :ok false
-        (= code Error$ErrorCode/STALE_OPERATION)
-        {:type :ok :swapped false}
+            ;; CAS failure (expected mismatch) is a definite :ok false
+            (= code Error$ErrorCode/STALE_OPERATION)
+            {:type :ok :swapped false}
 
-        :else
-        {:type (classify-error-code code) :error (str code)}))
-    (catch StatusRuntimeException e
-      (if (= (.getCode (.getStatus e)) io.grpc.Status$Code/DEADLINE_EXCEEDED)
-        {:type :info :error :deadline-exceeded}
-        {:type :info :error (str (.getStatus e))}))
-    (catch Exception e
-      {:type :info :error (str e)})))
+            :else
+            {:type (classify-error-code code) :error (str code)}))
+        (catch StatusRuntimeException e
+          (if (= (.getCode (.getStatus e)) io.grpc.Status$Code/DEADLINE_EXCEEDED)
+            {:type :info :error :deadline-exceeded}
+            {:type :info :error (str (.getStatus e))}))
+        (catch Exception e
+          {:type :info :error (str e)})))))

--- a/src/jepsen/d_engine/db.clj
+++ b/src/jepsen/d_engine/db.clj
@@ -66,7 +66,7 @@
                                  (catch Exception _ nil))]
                      (when ch
                        (try
-                         (when (= :ok (:type (grpc/lget ch 1)))
+                         (when (= :ok (:type (grpc/lget [ch] 1)))
                            node)
                          (finally (grpc/close-channel ch)))))))
            (remove nil?))))

--- a/src/jepsen/d_engine/nemesis.clj
+++ b/src/jepsen/d_engine/nemesis.clj
@@ -21,22 +21,3 @@
                  (some faults #{:kill :pause})    (conj (nc/db-package opts)))]
     (nc/compose-packages pkgs)))
 
-(defn full-generator
-  "Generator for mixed fault injection.
-  Cycles through network partitions, process kills, and process pauses."
-  [{:keys [interval] :or {interval 5}}]
-  (gen/phases
-   (cycle [(gen/sleep interval)
-           {:type :info, :f :start-partition}
-           (gen/sleep interval)
-           {:type :info, :f :stop-partition}
-
-           (gen/sleep interval)
-           {:type :info, :f :kill}
-           (gen/sleep (/ interval 2))
-           {:type :info, :f :start}
-
-           (gen/sleep interval)
-           {:type :info, :f :pause}
-           (gen/sleep (/ interval 2))
-           {:type :info, :f :resume}])))

--- a/src/jepsen/d_engine/set.clj
+++ b/src/jepsen/d_engine/set.clj
@@ -13,14 +13,14 @@
        (filter #(not= 0 (bit-and packed (bit-shift-left 1 %))))
        set))
 
-(defrecord SetClient [endpoints ch]
+(defrecord SetClient [endpoints channels]
   client/Client
 
   (open! [this test node]
-    (assoc this :ch (grpc/open-channel (grpc/find-endpoint endpoints node))))
+    (assoc this :channels (grpc/open-all-channels endpoints)))
 
   (setup! [this test]
-    (grpc/put! ch set-key 0))
+    (grpc/put! channels set-key 0))
 
   (invoke! [this test op]
     (case (:f op)
@@ -28,14 +28,14 @@
       (loop [attempts 0]
         (if (> attempts 50)
           (assoc op :type :fail :error :too-many-retries)
-          (let [res (grpc/lget ch set-key)]
+          (let [res (grpc/lget channels set-key)]
             (case (:type res)
               :info (assoc op :type :info :error (:error res))
               :fail (assoc op :type :fail :error (:error res))
               :ok
               (let [current (or (:value res) 0)
                     new-val (bit-or current (bit-shift-left 1 (long (:value op))))
-                    cas-res (grpc/cas! ch set-key current new-val)]
+                    cas-res (grpc/cas! channels set-key current new-val)]
                 (case (:type cas-res)
                   :ok   (if (:swapped cas-res)
                           (assoc op :type :ok)
@@ -44,7 +44,7 @@
                   :fail (assoc op :type :fail :error (:error cas-res))))))))
 
       :read
-      (let [res (grpc/lget ch set-key)]
+      (let [res (grpc/lget channels set-key)]
         (case (:type res)
           :ok   (assoc op :type :ok :value (decode-set (or (:value res) 0)))
           :info (assoc op :type :info :error (:error res))
@@ -53,12 +53,12 @@
   (teardown! [this test])
 
   (close! [this test]
-    (when ch (grpc/close-channel ch))))
+    (when channels (grpc/close-all-channels channels))))
 
 (defn add-op [_ _] {:type :invoke :f :add :value (rand-int 30)})
 (defn read-op [_ _] {:type :invoke :f :read :value nil})
 
 (defn workload [opts]
-  {:client    (SetClient. (:endpoints opts) nil)
+  {:client    (SetClient. (:endpoints opts) nil) ; channels populated in open!
    :checker   (checker/set-full)
    :generator (gen/mix [add-op read-op])})


### PR DESCRIPTION
## Summary

- **kill fault fix**: replace per-node gRPC channel with `open-all-channels` + `with-failover` — on node kill, clients automatically route to surviving nodes via shuffled channel retry, eliminating `:valid? :unknown` verdicts from the linearizability checker
- **nemesis crash fix**: `db.clj` primaries health check was passing a single `ManagedChannel` to `lget` (which now expects a vector); wrapping as `[ch]` prevents crash and false linearizability violations
- **nil-read fix**: `RegisterClient` read path now returns `:ok nil` for missing keys instead of `:fail :not-found` (correct for `cas-register` initial state)
- **dead code removal**: `full-generator` in `nemesis.clj` was never called; `nc/compose-packages` handles combined fault generators
- **new Makefile targets**: `test-stress` (RATE=200, 10 min) and `test-combined` (kill+partition, 5 min)

## Test plan

- [x] `make test WORKLOAD=register FAULTS=partition` ✅
- [x] `make test WORKLOAD=register FAULTS=kill` ✅ (no more `:valid? :unknown`)
- [x] `make test-combined WORKLOAD=register` ✅ kill+partition, RATE=50, 5 min
- [x] `make test WORKLOAD=register FAULTS=pause,partition TIME_LIMIT=120 RATE=50` ✅
- [x] `make test-stress WORKLOAD=register` ✅ RATE=200, 10 min

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `test-stress` and `test-combined` Makefile targets for running specialized Jepsen test scenarios with pre-configured fault injection parameters.

* **Refactor**
  * Enhanced multi-endpoint support and failover capabilities for improved test resilience and distributed system verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deventlab/d-engine-jepsen/pull/7)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->