### PR TITLE
fix(jepsen) #9: resolve test hang, set :unknown, and append Elle crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to d-engine-jepsen are documented here.
+Versions track d-engine releases — e.g. `v0.2.4` tests d-engine `v0.2.4`.
+
+---
+
+## [0.2.4] — 2026-05-12
+
+### Fixed
+
+- **`db/start!` hang** (`src/jepsen/d_engine/db.clj`)  
+  Replaced manual `bash -c '... &'` with `cu/start-daemon!` (`start-stop-daemon --background`).  
+  Root cause: `c/su` → `sudo` maintains a process session and waits for all descendants to exit.
+  A long-running backgrounded `demo` process caused `sudo` to never release the session,
+  so SSHJ's `c/exec` blocked indefinitely on every `:start :all` nemesis operation.
+  `start-stop-daemon --background` performs a kernel-level double-fork that fully escapes
+  the sudo session; the helper exits immediately and SSHJ returns normally.
+
+- **`set` workload: `:valid? :unknown` result** (`src/jepsen/d_engine/set.clj`)  
+  Changed add-value generation from `rand-int 30` to a unique sequential sequence `(range 63)`.  
+  Root cause: `set-full` checker resets an element's tracking state on every new `:invoke :add V`.
+  With repeated values and a cluster outage near the end of the test, all 30 elements had their
+  state reset after the last successful read, causing `:stable-count 0` → `:valid? :unknown`.
+
+- **`append` workload: Elle `AssertionError` crash** (`src/jepsen/d_engine/append.clj`)  
+  Added 8-bit overflow guard: when `next-val > 255`, `append-op` emits a read instead.  
+  Root cause: the global `next-val` counter grew to ~600 in a 120s test. Values ≥ 256 corrupted
+  the packed u64 encoding — `encode-append` of v=276 spread bits across adjacent slots, so
+  `decode` returned phantom values (e.g. 276 → [20, 1]) that no transaction ever wrote.
+  Elle's `dirty_update_cases` detected this as an impossible history and threw an `AssertionError`.
+
+### Added
+
+- **Final generator phase** (`src/jepsen/d_engine.clj`)  
+  After `TIME_LIMIT` expires the test now runs: stop all faults → sleep 10s → final client read.
+  Matches the etcd Jepsen reference pattern. Ensures the checker sees a confirmed read after
+  the cluster has recovered, allowing `set-full` to report `:stable` rather than `:never-read`.
+
+- **`set` workload `:final-generator`** (`src/jepsen/d_engine/set.clj`)  
+  Added `(gen/once read-op)` as the workload's final generator, used by the final phase above.
+
+### Verified
+
+All four workloads pass under `FAULTS=kill,partition` and `FAULTS=all` with `TIME_LIMIT=120`:
+
+| Workload   | `FAULTS=kill,partition` | `FAULTS=all` |
+| ---------- | ----------------------- | ------------ |
+| `register` | ✅ PASS                  | ✅ PASS       |
+| `bank`     | ✅ PASS                  | ✅ PASS       |
+| `set`      | ✅ PASS                  | ✅ PASS       |
+| `append`   | ✅ PASS                  | ✅ PASS       |
+
+---
+
+## [0.2.3] and earlier
+
+See git log for history prior to v0.2.4.

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ This test suite requires two d-engine binaries:
 
 1. **three-nodes-embedded** - d-engine standalone cluster binary
    - Source: [examples/three-nodes-embedded](https://github.com/DEventLab/d-engine/tree/main/examples/three-nodes-embedded)
-   - Version: d-engine v0.2+
+   - Version: d-engine v0.2.4
    - Purpose: Runs a 3-node Raft cluster for testing
 
 2. **dengine_ctl** - d-engine client CLI tool
    - Source: [examples/client-usage-standalone](https://github.com/DEventLab/d-engine/tree/main/examples/client-usage-standalone)
-   - Version: d-engine v0.2+
+   - Version: d-engine v0.2.4
    - Purpose: Client to interact with the cluster (put/get operations)
 
 Both binaries are automatically downloaded from S3 during test setup. The download URLs are configured via `S3_BASE_URL` in `.env`.
@@ -139,24 +139,52 @@ make view
 ### Run Tests
 
 ```bash
-make test TIME_LIMIT=120
+# Default (register workload, partition fault, 60s)
+make test
+
+# Full parameter example
+make test WORKLOAD=set FAULTS=kill,partition TIME_LIMIT=120 RATE=20
 ```
 
-### Environment Variables
+### Test Parameters
 
-| Variable        | Default               | Description                |
-| --------------- | --------------------- | -------------------------- |
-| `TIME_LIMIT`    | 60                    | Test duration in seconds   |
-| `ENDPOINTS`     | http://node1:9081,... | d-engine endpoints         |
-| `SSH_KEYS_PATH` | ./sshkeys             | Path to SSH keys directory |
+| Parameter          | Default      | Options / Description |
+| ------------------ | ------------ | --------------------- |
+| `WORKLOAD`         | `register`   | `register` `bank` `set` `append` — which correctness property to test (see [Workloads](#workloads)) |
+| `FAULTS`           | `partition`  | `partition` `kill` `pause` `all` (comma-separated) — which failure modes to inject |
+| `TIME_LIMIT`       | `60`         | Test duration in seconds. 120 is a reasonable default; use 300+ for soak tests |
+| `RATE`             | `10`         | Target client operations per second. Higher values increase concurrency stress |
+| `NEMESIS_INTERVAL` | `10`         | Seconds between nemesis actions. Lower = faults arrive more frequently |
 
-### Binary Caching
+**`WORKLOAD` — what to test:**
 
-Binaries are downloaded once to `./bin/` and mounted into containers:
+| Value      | Tests what?                             | Checker |
+| ---------- | --------------------------------------- | ------- |
+| `register` | Single-key read/write is linearizable   | Knossos |
+| `bank`     | Transfers never lose or create money    | balance invariant |
+| `set`      | Every acknowledged add survives faults  | set-full |
+| `append`   | List-append has no ordering anomalies   | Elle |
+
+**`FAULTS` — how to break the cluster:**
+
+| Value       | What it does |
+| ----------- | ------------ |
+| `partition` | iptables network partition (majority / minority / primaries) |
+| `kill`      | SIGKILL the demo process on a minority of nodes |
+| `pause`     | SIGSTOP / SIGCONT (simulates a slow/frozen node) |
+| `all`       | All three combined |
+
+### Convenience Targets
 
 ```bash
-# Force re-download binaries
-make force-download
+# Run all four workloads sequentially (stops on first failure)
+make test-all FAULTS=kill,partition TIME_LIMIT=120
+
+# High-concurrency stress test (rate=200, 10 min)
+make test-stress WORKLOAD=set
+
+# Combined faults, moderate rate, 5 min
+make test-combined WORKLOAD=bank
 ```
 
 ### Other Commands

--- a/src/jepsen/d_engine.clj
+++ b/src/jepsen/d_engine.clj
@@ -93,13 +93,19 @@
                :pause     {:targets [:all]}
                :kill      {:targets [:minority]}
                :interval  (:nemesis-interval opts)})
-        gen (->> (:generator wl)
-                 (gen/stagger (/ 1 (:rate opts)))
-                 (gen/nemesis
-                   (gen/phases
-                     (gen/sleep 5)
-                     (:generator nem)))
-                 (gen/time-limit (:time-limit opts)))]
+        gen (gen/phases
+              (->> (:generator wl)
+                   (gen/stagger (/ 1 (:rate opts)))
+                   (gen/nemesis
+                     (gen/phases
+                       (gen/sleep 5)
+                       (:generator nem)))
+                   (gen/time-limit (:time-limit opts)))
+              (gen/log "Healing cluster")
+              (gen/nemesis (:final-generator nem))
+              (gen/log "Waiting for recovery")
+              (gen/sleep 10)
+              (gen/clients (:final-generator wl)))]
     (merge tests/noop-test
            opts
            {:name      (str "d-engine-" (:workload opts "register"))

--- a/src/jepsen/d_engine/append.clj
+++ b/src/jepsen/d_engine/append.clj
@@ -73,9 +73,16 @@
   (close! [this test]
     (when channels (grpc/close-all-channels channels))))
 
+; slot-bits=8 → valid values 1-255. When exhausted, fall back to reads so
+; values never overflow the encoding and remain globally unique for Elle.
+(def max-val (dec (bit-shift-left 1 slot-bits)))  ; 255
+
 (defn append-op [_ _]
-  {:type :invoke :f :txn
-   :value [[:append (rand-int n-keys) (swap! next-val inc)]]})
+  (let [v (swap! next-val inc)]
+    {:type :invoke :f :txn
+     :value (if (<= v max-val)
+              [[:append (rand-int n-keys) v]]
+              [[:r (rand-int n-keys) nil]])}))
 
 (defn read-op [_ _]
   {:type :invoke :f :txn

--- a/src/jepsen/d_engine/db.clj
+++ b/src/jepsen/d_engine/db.clj
@@ -22,21 +22,24 @@
   (c/su (cu/grepkill! binary)))
 
 (defn start!
-  "Restarts the demo binary. Env vars are reconstructed from node identity
-  since SSH sessions don't inherit docker-compose environment."
+  "Starts the demo binary if not already running.
+  Uses start-stop-daemon --background (double-fork) to fully escape the
+  sudo session that nohup/setsid cannot break out of."
   [node]
   (let [id    (node-id node)
         conf  (str "/app/config/n" id)
         log   (str "/app/logs/" id)
         mport (+ 8080 id)]
     (c/su
-      (c/exec :bash :-c
-        (str "nohup env"
-             " CONFIG_PATH=" conf
-             " LOG_DIR=" log
-             " METRICS_PORT=" mport
-             " RUST_LOG=demo=debug,d_engine=debug,hyper=warn,sled=warn"
-             " /usr/local/bin/demo >> " logfile " 2>&1 &")))))
+      (cu/start-daemon!
+        {:logfile logfile
+         :pidfile "/app/demo.pid"
+         :chdir   "/app"
+         :env     {"CONFIG_PATH"  conf
+                   "LOG_DIR"      log
+                   "METRICS_PORT" (str mport)
+                   "RUST_LOG"     "demo=debug,d_engine=debug,hyper=warn,sled=warn"}}
+        "/usr/local/bin/demo"))))
 
 (defrecord DB []
   db/DB

--- a/src/jepsen/d_engine/set.clj
+++ b/src/jepsen/d_engine/set.clj
@@ -55,10 +55,12 @@
   (close! [this test]
     (when channels (grpc/close-all-channels channels))))
 
-(defn add-op [_ _] {:type :invoke :f :add :value (rand-int 30)})
 (defn read-op [_ _] {:type :invoke :f :read :value nil})
 
 (defn workload [opts]
-  {:client    (SetClient. (:endpoints opts) nil) ; channels populated in open!
-   :checker   (checker/set-full)
-   :generator (gen/mix [add-op read-op])})
+  {:client          (SetClient. (:endpoints opts) nil)
+   :checker         (checker/set-full)
+   :generator       (gen/mix [(->> (range 63)
+                                   (map (fn [v] {:type :invoke :f :add :value v})))
+                               (repeatedly #(read-op nil nil))])
+   :final-generator (gen/once read-op)})


### PR DESCRIPTION

## Changes

**`db/start!` — fix SSHJ hang on `:start :all`**
Replaced `bash -c '... &'` with `cu/start-daemon!`. Root cause: `c/su` → `sudo` holds the process session open until all descendants exit; a successfully-started `demo` server never exits, so `c/exec` blocks forever. `start-stop-daemon --background` performs a kernel-level double-fork and fully escapes the sudo session.

**`set` workload — fix `:valid? :unknown`**
Switched add-value generation from `rand-int 30` to `(range 63)` unique sequential values. Root cause: `set-full` resets an element's tracking state on each new `:invoke :add V`; with repeated values and a cluster outage, all 30 elements had their state wiped after the last successful read. Also added a final generator phase: stop faults → sleep 10s → confirmed read.

**`append` workload — fix Elle `AssertionError` crash**
Added overflow guard: when `next-val > 255`, emit a read instead of an append. Root cause: the global counter reached ~600 in a 120s test, exceeding the 8-bit slot limit. Values ≥ 256 corrupt adjacent slots in the packed u64 encoding, producing phantom decoded values that no transaction ever wrote — crashing Elle's internal assertion.

## Docs

- **README**: new Test Parameters section explaining `WORKLOAD`, `FAULTS`, `TIME_LIMIT`, `RATE`, `NEMESIS_INTERVAL`
- **CHANGELOG**: created `CHANGELOG.md`, documents v0.2.4 fixes and verified test matrix

## Verified

All 4 workloads pass under `FAULTS=kill,partition` and `FAULTS=all` with `TIME_LIMIT=120`.

| Workload | `kill,partition` | `all` |
|----------|-----------------|-------|
| `register` | ✅ | ✅ |
| `bank` | ✅ | ✅ |
| `set` | ✅ | ✅ |
| `append` | ✅ | ✅ |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added final generator phase for comprehensive test result capture.

* **Bug Fixes**
  * Fixed append workload crash caused by encoding overflow.
  * Improved Jepsen daemon startup behavior and reliability.
  * Enhanced set workload stability under unknown validity conditions.

* **Documentation**
  * Updated README with concrete v0.2.4 binary version specifications.
  * Added detailed usage examples and parameterized test commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deventlab/d-engine-jepsen/pull/10)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->