### PR TITLE
feat(jepsen) #11: upgrade append checker to :strict-serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ Versions track d-engine releases — e.g. `v0.2.4` tests d-engine `v0.2.4`.
 
 ---
 
-## [0.2.4] — 2026-05-12
+## [0.2.4] — 2026-05-13
+
+### Changed
+
+- **`append` workload: upgrade consistency model to `:strict-serializable`** (`src/jepsen/d_engine/append.clj`)  
+  Changed `:consistency-models [:sequential]` → `[:strict-serializable]`. Sequential consistency
+  only verifies per-process ordering; strict serializability matches d-engine's actual Raft
+  guarantee (linearizability) and catches stale reads — a client seeing outdated data after
+  another client's write has already been committed and acknowledged.  
+  Also fixed docstring: encoding range is values 1–255 (not 1–127).
 
 ### Fixed
 

--- a/src/jepsen/d_engine/append.clj
+++ b/src/jepsen/d_engine/append.clj
@@ -1,6 +1,6 @@
 (ns jepsen.d_engine.append
   "Append workload: checks list-append histories for anomalies using Elle.
-   Encodes an ordered sequence as a packed u64 (8 bits x 7 slots, values 1-127).
+   Encodes an ordered sequence as a packed u64 (8 bits x 7 slots, values 1-255).
    Uses CAS-based atomic append; Elle detects ordering anomalies (G-single, etc.)."
   (:require [jepsen [client :as client]
                     [generator :as gen]]
@@ -90,6 +90,6 @@
 
 (defn workload [opts]
   {:client    (AppendClient. (:endpoints opts) nil) ; channels populated in open!
-   :checker   (append/checker {:consistency-models [:sequential]
+   :checker   (append/checker {:consistency-models [:strict-serializable]
                                :anomalies          [:G-single]})
    :generator (gen/mix [append-op read-op])})


### PR DESCRIPTION
- Change :consistency-models [:sequential] → [:strict-serializable] to verify d-engine's linearizability guarantee under faults; catches stale reads that :sequential cannot detect
- Fix docstring: encoding range is values 1-255 (not 1-127)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated append workload consistency model to strict-serializable for enhanced isolation guarantees.
  * Corrected append encoding specification: valid values are now in the 1–255 range (previously documented as 1–127).

* **Documentation**
  * Updated changelog entry date and documented recent workload configuration adjustments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deventlab/d-engine-jepsen/pull/13)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->