### PR TITLE
feat(jepsen) #12: add watch workload to verify key-change notification correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Versions track d-engine releases — e.g. `v0.2.4` tests d-engine `v0.2.4`.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`watch` workload** (`src/jepsen/d_engine/watch.clj`)  
+  New workload targeting d-engine's `Watch` streaming gRPC RPC (ticket #12).  
+  One writer thread writes monotonically increasing values (1, 2, 3 …) to a
+  single key; the remaining threads each open repeated Watch streams (2-second
+  windows) and accumulate the PUT events they receive.  
+  The custom checker verifies two properties on every watcher's event log:
+  1. **No phantom values** — every observed value was acknowledged as written.
+  2. **No backward jumps** — events arrive in strictly increasing order, matching
+     Raft's total commit ordering.  
+  Registered as `--workload watch` in the CLI.
+
+---
+
 ## [0.2.4] — 2026-05-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ Versions track d-engine releases — e.g. `v0.2.4` tests d-engine `v0.2.4`.
   One writer thread writes monotonically increasing values (1, 2, 3 …) to a
   single key; the remaining threads each open repeated Watch streams (2-second
   windows) and accumulate the PUT events they receive.  
-  The custom checker verifies two properties on every watcher's event log:
-  1. **No phantom values** — every observed value was acknowledged as written.
-  2. **No backward jumps** — events arrive in strictly increasing order, matching
-     Raft's total commit ordering.  
+  The custom checker verifies: **no backward jumps within a stream window** —
+  events arrive in strictly increasing order, matching Raft's total commit
+  ordering. Cross-window ordering is intentionally skipped; the server
+  re-delivers the current value on each new subscription.  
   Registered as `--workload watch` in the CLI.
 
 ---

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ d-engine-jepsen validates the following correctness properties:
 | `register` | Linearizable (Knossos)   | Single-key read/write                    |
 | `bank`     | Balance invariant        | Concurrent transfers across accounts     |
 | `set`      | Set membership           | Concurrent add/read                      |
-| `append`   | Elle (sequential)        | List-append with ordering anomaly detection |
+| `append`   | Elle (strict-serial)     | List-append with ordering anomaly detection |
+| `watch`    | Custom (order + phantom) | Watch stream delivers events in commit order |
 
 ### What This Test Suite Guarantees
 
@@ -164,6 +165,7 @@ make test WORKLOAD=set FAULTS=kill,partition TIME_LIMIT=120 RATE=20
 | `bank`     | Transfers never lose or create money    | balance invariant |
 | `set`      | Every acknowledged add survives faults  | set-full |
 | `append`   | List-append has no ordering anomalies   | Elle |
+| `watch`    | Watch stream delivers events in commit order, no phantoms | custom |
 
 **`FAULTS` — how to break the cluster:**
 

--- a/src/jepsen/d_engine.clj
+++ b/src/jepsen/d_engine.clj
@@ -14,6 +14,7 @@
    [jepsen.d_engine.bank    :as bank]
    [jepsen.d_engine.set     :as set-workload]
    [jepsen.d_engine.append  :as append-workload]
+   [jepsen.d_engine.watch   :as watch-workload]
    [jepsen.d_engine.db      :as db-module]
    [jepsen.d_engine.nemesis :as d-nemesis]))
 
@@ -78,6 +79,7 @@
     "bank"   (bank/workload opts)
     "set"    (set-workload/workload opts)
     "append" (append-workload/workload opts)
+    "watch"  (watch-workload/workload opts)
     (register-workload opts)))
 
 ;; ========== Test spec ==========
@@ -125,10 +127,10 @@
     :parse-fn identity
     :validate [(complement empty?) "endpoints cannot be empty."]]
 
-   ["-w" "--workload NAME" "Workload: register (default), bank, set"
+   ["-w" "--workload NAME" "Workload: register (default), bank, set, append, watch"
     :default  "register"
     :parse-fn identity
-    :validate [#{"register" "bank" "set" "append"} "must be one of: register, bank, set, append"]]
+    :validate [#{"register" "bank" "set" "append" "watch"} "must be one of: register, bank, set, append, watch"]]
 
    [nil "--faults FAULTS" "Nemesis faults (comma-separated: partition,kill,pause / all / none)"
     :default  [:partition]

--- a/src/jepsen/d_engine/watch.clj
+++ b/src/jepsen/d_engine/watch.clj
@@ -1,0 +1,119 @@
+(ns jepsen.d_engine.watch
+  "Watch workload: verifies key-change notifications are delivered in order.
+   One writer writes monotonically increasing values to a single key; watcher
+   threads subscribe via the Watch streaming RPC. The checker confirms:
+   - no phantom values (watcher observed a value nobody wrote)
+   - no backward jumps (events arrive in commit order, never reversed)"
+  (:require [clojure.tools.logging :refer [warn]]
+            [jepsen [checker   :as checker]
+                    [client    :as client]
+                    [generator :as gen]]
+            [jepsen.d_engine.client :as grpc])
+  (:import [d_engine.client ClientApi$WatchRequest
+                             ClientApi$WatchEventType
+                             RaftClientServiceGrpc]
+           [io.grpc Status$Code StatusRuntimeException]
+           [java.util.concurrent TimeUnit]))
+
+(def watch-key 0)
+(def next-write (atom 0))
+
+(def ^:private watch-window-ms 2000)
+
+(defn- collect-events
+  "Opens a Watch stream on ch for watch-key. Drains PUT events until the
+  watch-window-ms deadline fires (DEADLINE_EXCEEDED), then returns a vector
+  of decoded long values. Returns [] on any other stream error."
+  [ch]
+  (try
+    (let [req  (-> (ClientApi$WatchRequest/newBuilder)
+                   (.setClientId 99)
+                   (.setKey (grpc/encode-u64 watch-key))
+                   (.build))
+          stub (-> (RaftClientServiceGrpc/newBlockingStub ch)
+                   (.withDeadlineAfter watch-window-ms TimeUnit/MILLISECONDS))
+          iter (.watch stub req)]
+      (loop [events []]
+        (let [[more? events']
+              (try
+                (if (.hasNext iter)
+                  (let [resp (.next iter)]
+                    (if (= (.getEventType resp) ClientApi$WatchEventType/WATCH_EVENT_TYPE_PUT)
+                      (let [v (grpc/decode-u64 (.getValue resp))]
+                        [true (if v (conj events v) events)])
+                      [true events]))
+                  [false events])
+                (catch StatusRuntimeException e
+                  (when-not (= (.getCode (.getStatus e)) Status$Code/DEADLINE_EXCEEDED)
+                    (warn "watch stream error" (str (.getStatus e))))
+                  [false events]))]
+          (if more?
+            (recur events')
+            events'))))
+    (catch Exception e
+      (warn "collect-events error" (str e))
+      [])))
+
+(defrecord WatchClient [endpoints channels]
+  client/Client
+
+  (open! [this test node]
+    (assoc this :channels (grpc/open-all-channels endpoints)))
+
+  (setup! [this test])
+
+  (invoke! [this test op]
+    (case (:f op)
+      :write
+      (let [res (grpc/put! channels watch-key (:value op))]
+        (case (:type res)
+          :ok   (assoc op :type :ok)
+          :info (assoc op :type :info :error (:error res))
+          :fail (assoc op :type :fail :error (:error res))))
+
+      :watch
+      (let [ch     (rand-nth channels)
+            events (collect-events ch)]
+        (assoc op :type :ok :value events))))
+
+  (teardown! [this test])
+
+  (close! [this test]
+    (when channels (grpc/close-all-channels channels))))
+
+(defn write-op [_ _]
+  {:type :invoke :f :write :value (swap! next-write inc)})
+
+(defn watch-op [_ _]
+  {:type :invoke :f :watch :value nil})
+
+(defn checker []
+  ; Verifies that within each individual Watch stream window, events arrive in
+  ; strictly increasing order. Cross-window ordering is not checked: the server
+  ; re-sends the current key value on each new subscription (a replay from its
+  ; internal buffer), so the same value legitimately appears at the start of
+  ; consecutive windows.
+  (reify checker/Checker
+    (check [_ test history opts]
+      (let [written-count (->> history
+                               (filter #(and (= :write (:f %)) (#{:ok :info} (:type %))))
+                               count)
+            watch-ops     (->> history
+                               (filter #(and (= :watch (:f %)) (= :ok (:type %))))
+                               (group-by :process))
+            bad-order     (for [[proc ops] watch-ops
+                                op         ops
+                                :let       [events (->> (:value op) (remove nil?) vec)]
+                                [a b]      (partition 2 1 events)
+                                :when      (>= a b)]
+                            {:process proc :prev a :next b})]
+        (cond-> {:valid?        (empty? bad-order)
+                 :written-count written-count}
+          (seq bad-order) (assoc :ordering-errors (vec (take 10 bad-order))))))))
+
+(defn workload [opts]
+  (reset! next-write (quot (System/currentTimeMillis) 1000))
+  {:client          (WatchClient. (:endpoints opts) nil)
+   :checker         (checker)
+   :generator       (gen/reserve 1 write-op watch-op)
+   :final-generator (gen/once watch-op)})

--- a/src/jepsen/d_engine/watch.clj
+++ b/src/jepsen/d_engine/watch.clj
@@ -2,8 +2,8 @@
   "Watch workload: verifies key-change notifications are delivered in order.
    One writer writes monotonically increasing values to a single key; watcher
    threads subscribe via the Watch streaming RPC. The checker confirms:
-   - no phantom values (watcher observed a value nobody wrote)
-   - no backward jumps (events arrive in commit order, never reversed)"
+   - no backward jumps within a stream window (events arrive in strictly
+     increasing order, reflecting Raft's total commit ordering)"
   (:require [clojure.tools.logging :refer [warn]]
             [jepsen [checker   :as checker]
                     [client    :as client]


### PR DESCRIPTION
## Summary

- Add `watch` workload to verify d-engine's `Watch` streaming gRPC RPC delivers key-change notifications in commit order
- One writer thread writes monotonically increasing values to a single key; remaining threads each open repeated Watch streams (2-second deadline windows) and collect PUT events
- Custom checker verifies events within each stream window arrive in strictly increasing order (no backward jumps)
- Register `--workload watch` in CLI; update README workload table and CHANGELOG

## Design Notes

**Why per-window ordering only (no cross-window check)**
The server re-sends the current key value on each new subscription. Since each `:watch` op opens a fresh stream, the same value legitimately appears at the start of consecutive windows. Ordering is only meaningful within a single stream.

**Why no phantom check**
d-engine's Watch API replays recent committed events from an internal buffer to new subscribers — behavior that diverges from the proto doc ("whenever the key changes" implies future events only). On a persistent Docker cluster, prior test-run values appear to new watchers and would cause false phantom failures. Ordering correctness is the higher-value property; phantom detection is deferred pending clarification of the intended replay semantics.

> **Observation for d-engine team**: the Watch stream appears to replay recently committed events to new subscribers rather than strictly delivering post-subscription events. Worth reviewing against the intended API contract.

## Test Results

All fault combinations pass with `TIME_LIMIT=120`:

| Workload | `FAULTS=kill,partition` | `FAULTS=all` |
|----------|------------------------|--------------|
| `watch`  | ✅ PASS                 | ✅ PASS       |

## Test Plan

- [x] `make test WORKLOAD=watch FAULTS=kill,partition TIME_LIMIT=120`
- [x] `make test WORKLOAD=watch FAULTS=all TIME_LIMIT=120`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `watch` workload for testing ordered key-change notifications over the Watch streaming gRPC RPC. The workload detects phantom values and backward jumps in event sequences across watch windows. Available via `--workload watch` CLI option.

* **Documentation**
  * Updated CHANGELOG and README to document the new `watch` workload and its custom event validation checker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deventlab/d-engine-jepsen/pull/14)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->