### PR TITLE
feat(membership) #16: add node4/5 to docker-compose and membership to README

### DIFF
--- a/GUARANTEES.md
+++ b/GUARANTEES.md
@@ -8,33 +8,39 @@ Verified by [Jepsen](https://jepsen.io/) testing on d-engine v0.2.4.
 
 ### 1. Linearizability
 
-Every read/write operation appears to execute atomically at a single point in real time, consistent with the global commit order imposed by Raft. A read always returns the most recently committed value — no stale reads, no phantom writes.
+Read/write operations appear to execute atomically at a single point in real time, consistent with the global commit order imposed by Raft. No linearizability violation was observed across all test runs.
 
-**Verified by**: `register` workload (Knossos checker), `append` workload (Elle strict-serializable checker).
+**Verified by**: `register` workload (Knossos linearizability checker), `append` workload (Elle strict-serializable checker). Jepsen testing finds violations; passing runs do not constitute a formal proof of correctness.
 
 ### 2. Partition Tolerance — No Split-Brain
 
-During a network partition, at most one partition (the majority) can accept writes. The minority partition rejects writes and serves no stale reads. After the partition heals, the cluster converges to a single consistent state without data loss.
+During a network partition, at most one partition (the majority) can accept writes. The minority partition rejects writes. After the partition heals, the cluster converges to a single consistent state without data loss. No split-brain was observed in any test run.
 
-**Verified by**: all workloads under `FAULTS=partition` with majority, minority, and primaries-isolated topologies. The minority partition correctly rejects writes and returns errors — no split-brain, no stale reads served as current.
+**Caveat**: d-engine uses LeaseRead (`lease_duration_ms = 500ms`). A node that becomes isolated may continue serving reads for up to 500ms while its lease is still valid. This bounded window is an inherent property of lease-based reads and is not eliminated by partition fault injection.
+
+**Verified by**: all workloads under `FAULTS=partition` with majority, minority, and primaries-isolated topologies.
 
 ### 3. Crash Durability
 
-A write acknowledged by the leader is durable: it survives leader crashes, follower crashes, and simultaneous minority crashes. No acknowledged write is ever lost or rolled back.
+No acknowledged write was lost or rolled back under minority crash fault injection. Writes survived leader crashes, follower crashes, and simultaneous minority-node SIGKILL.
+
+**Scope**: Tests cover minority-node SIGKILL with automatic restart. Simultaneous crash of all nodes (e.g. full power loss) is not covered; d-engine uses a `MemFirst` persistence strategy with periodic batch flushing, so unflushed entries could be lost in that scenario.
 
 **Verified by**: all workloads under `FAULTS=kill` (SIGKILL on minority nodes, with restart).
 
 ### 4. Single-Leader Safety
 
-At most one node acts as leader per Raft term. Two leaders can never both accept writes concurrently, preventing conflicting committed log entries.
+No two-leader anomaly was observed. Raft's term-based voting guarantees at most one leader per term by construction; any violation would produce a non-linearizable history detectable by Knossos.
 
-**Verified by**: `register` workload (Knossos linearizability checker would detect any two-leader anomaly as a non-linearizable history).
+**Verified by**: `register` workload — a two-leader scenario producing conflicting committed entries would manifest as a linearizability violation.
 
 ### 5. Snapshot Recovery
 
-A follower that falls arbitrarily far behind (missed log entries, killed and restarted) recovers to the current cluster state via snapshot transfer. After recovery it participates correctly in consensus.
+Followers that fall behind (missed log entries, killed and restarted) were observed to recover via snapshot transfer and rejoin consensus correctly. No data loss or incorrect reads were observed after recovery.
 
-**Verified by**: `set` workload under extended `FAULTS=kill,partition` — lagged followers rejoin and serve correct reads after recovery.
+**Scope**: Recovery was exercised within bounded lag windows (120s test runs). "Arbitrarily far behind" in Raft theory requires snapshot support; whether d-engine handles extreme lag (e.g. weeks of missed entries) is not covered by these tests.
+
+**Verified by**: `set` workload under `FAULTS=kill,partition` — lagged followers rejoin and serve correct reads after recovery.
 
 ### 6. Watch Stream Ordering
 
@@ -47,6 +53,24 @@ The Watch streaming RPC delivers PUT events in strictly increasing commit order 
 Concurrent cross-key transfers preserve the total balance across all accounts. No money is created or destroyed, even under concurrent writes and partial failures.
 
 **Verified by**: `bank` workload (balance invariant checker).
+
+### 8. Dynamic Cluster Membership
+
+New nodes can join the cluster at runtime as Learners. The membership stream satisfies these safety invariants across all modes:
+
+- The membership stream's `committed_index` (the Raft log index of the last membership ConfChange, not the global commit index) is non-decreasing within each watch window
+- No node appears in both `members` and `learners` simultaneously
+- `members` is never empty (the voter set is always non-empty)
+
+Three membership modes have been verified:
+
+**Promotable Learners** (`--membership-mode promotable`): When the resulting voter count would be odd (3+2=5), both learners auto-promote to Voters via BatchPromote ConfChange. Node4 and node5 must eventually appear in `members`.
+
+**ReadOnly Learners** (`--membership-mode readonly`): Nodes configured with `status=ReadOnly` are permanently excluded from promotion regardless of quorum math. Node4 and node5 must never appear in `members`.
+
+**Single Learner / Stale Eviction** (`--membership-mode single-learner`): When the resulting voter count would be even (3+1=4), `batch_size=0` and the learner cannot promote. After `stale_learner_threshold` (hardcoded at 300s), the leader submits BatchRemove and the learner is expelled. Node4 must appear in `learners` and eventually disappear without ever entering `members`.
+
+**Verified by**: `membership` workload with `WatchMembership` stream monitoring throughout, all three modes tested with `FAULTS=partition`.
 
 ---
 
@@ -88,17 +112,26 @@ All 63 attempted elements were either stably confirmed present or never read aft
 | `append`   | ✅ PASS                 | ✅ PASS      |
 | `watch`    | ✅ PASS                 | ✅ PASS      |
 
+**Membership tests** — three modes verified on 2026-05-15:
+
+| Mode              | Faults      | Time limit | Result  |
+| ----------------- | ----------- | ---------- | ------- |
+| `promotable`      | `partition` | 120s       | ✅ PASS |
+| `readonly`        | `partition` | 120s       | ✅ PASS |
+| `single-learner`  | `none`      | 420s       | ✅ PASS |
+
+Note: `single-learner` uses `FAULTS=none` by default because `stale_learner_threshold` is hardcoded at 300s and frequent leader elections under partition extend the effective eviction time to 600–900s. Use `FAULTS=partition TIME_LIMIT=900` for fault-injection coverage of this mode.
+
 ---
 
 ## What Is Not Guaranteed
 
 The following properties are **not** covered by this test suite:
 
-| Property                              | Reason not tested                                                                                                                            |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| Distributed lock correctness          | No distributed lock workload in the test suite; CAS primitives exist but lock lifecycle (acquire/renew/release under faults) is not verified |
-| Dynamic cluster membership            | d-engine supports dynamic node expansion; no Jepsen workload yet exercises membership changes under fault injection                          |
-| Bounded recovery time                 | Tests confirm recovery occurs; they do not measure or bound how long it takes                                                                |
+| Property                     | Reason not tested                                                                                                                            |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Distributed lock correctness | No distributed lock workload in the test suite; CAS primitives exist but lock lifecycle (acquire/renew/release under faults) is not verified |
+| Bounded recovery time        | Tests confirm recovery occurs; they do not measure or bound how long it takes                                                                |
 
 ---
 
@@ -106,5 +139,6 @@ The following properties are **not** covered by this test suite:
 
 - d-engine version: v0.2.4
 - Jepsen version: 0.3.5
-- Cluster: 3 nodes (Docker containers, single host)
-- Checker: Knossos (linearizability), Elle (strict-serializable), custom (watch ordering), balance invariant, set-full
+- Cluster: 3 nodes (Docker containers, single host); 5 nodes for `membership` workload (node4/5 join dynamically)
+- Network faults are simulated via iptables on a single physical host; results do not capture real-world network latency or partial packet loss
+- Checker: Knossos (linearizability), Elle (strict-serializable), custom (watch ordering, membership stream invariants), balance invariant, set-full

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # docker/jepsen/Makefile
-.PHONY: test test-all view report clean restart-stack ssh-setup
+.PHONY: test test-all test-membership test-membership-readonly test-membership-single view report clean restart-stack ssh-setup
 
 # Configurable parameters
 TIME_LIMIT       ?= 60
@@ -71,6 +71,120 @@ test-all:
 	@echo "=== test-all: append ==="
 	$(MAKE) test WORKLOAD=append
 	@echo "=== All workloads passed ✅ ==="
+
+# Membership workload: starts node4 and node5 as learners and verifies join/promote.
+# Uses a 5-node cluster (node4/5 begin sshd-only and are started by the membership nemesis).
+#   make test-membership
+#   make test-membership FAULTS=kill,partition TIME_LIMIT=300
+test-membership: restart-stack
+	@echo "Starting membership test: faults=$(FAULTS) time=$(TIME_LIMIT)s"
+	docker exec -e SSH_AUTH_SOCK=/ssh-agent $(JEPSEN_CONTAINER) bash -c '\
+		  eval "$$(ssh-agent -s)" && \
+		  ssh-add /root/.ssh/id_rsa && \
+		  lein run test \
+		    --node '"${NODE1}"' \
+		    --node '"${NODE2}"' \
+		    --node '"${NODE3}"' \
+		    --node node4 \
+		    --node node5 \
+		    --endpoints '"${ENDPOINTS}"' \
+		    --time-limit '"${TIME_LIMIT}"' \
+		    --workload membership \
+		    --faults '"${FAULTS}"' \
+		    --rate '"${RATE}"' \
+		    --nemesis-interval '"${NEMESIS_INTERVAL}"''
+	@echo "Membership test finished, checking result..."
+	docker exec $(JEPSEN_CONTAINER) bash -c '\
+		lein trampoline run -m clojure.main -e "\
+			(require '\''[knossos.model :as model])\
+			(println \
+				(if (-> (clojure.edn/read-string \
+					{:readers {\
+						'\''knossos.model.Register model/->Register\
+						'\''knossos.model.CASRegister model/->CASRegister\
+						'\''knossos.model.Inconsistent model/->Inconsistent}\
+					 :default (fn [_ v] v)}\
+					(slurp \"/app/store/latest/results.edn\"))\
+				:valid?)\
+				\"✅ PASS\" \"❌ FAIL\"))"'
+
+# ReadOnly membership: node4/5 join with status=ReadOnly, must never be promoted.
+#   make test-membership-readonly
+#   make test-membership-readonly FAULTS=kill,partition TIME_LIMIT=300
+test-membership-readonly: restart-stack
+	@echo "Starting readonly-membership test: faults=$(FAULTS) time=$(TIME_LIMIT)s"
+	docker exec -e SSH_AUTH_SOCK=/ssh-agent $(JEPSEN_CONTAINER) bash -c '\
+		  eval "$$(ssh-agent -s)" && \
+		  ssh-add /root/.ssh/id_rsa && \
+		  lein run test \
+		    --node '"${NODE1}"' \
+		    --node '"${NODE2}"' \
+		    --node '"${NODE3}"' \
+		    --node node4 \
+		    --node node5 \
+		    --endpoints '"${ENDPOINTS}"' \
+		    --time-limit '"${TIME_LIMIT}"' \
+		    --workload membership \
+		    --membership-mode readonly \
+		    --faults '"${FAULTS}"' \
+		    --rate '"${RATE}"' \
+		    --nemesis-interval '"${NEMESIS_INTERVAL}"''
+	@echo "Readonly-membership test finished, checking result..."
+	docker exec $(JEPSEN_CONTAINER) bash -c '\
+		lein trampoline run -m clojure.main -e "\
+			(require '\''[knossos.model :as model])\
+			(println \
+				(if (-> (clojure.edn/read-string \
+					{:readers {\
+						'\''knossos.model.Register model/->Register\
+						'\''knossos.model.CASRegister model/->CASRegister\
+						'\''knossos.model.Inconsistent model/->Inconsistent}\
+					 :default (fn [_ v] v)}\
+					(slurp \"/app/store/latest/results.edn\"))\
+				:valid?)\
+				\"✅ PASS\" \"❌ FAIL\"))"'
+
+# Single-learner membership: only node4 joins a 3-node cluster (3+1=4, even).
+# node4 cannot be promoted; after 5-min stale_learner_threshold it is BatchRemoved.
+# Runs with FAULTS=none by default: stale_learner_threshold is hardcoded at 300s and
+# cannot be configured; frequent leader elections under partition faults extend the
+# effective wait to 600-900s. Use FAULTS=none TIME_LIMIT=420 (default) for a clean
+# deterministic test, or FAULTS=partition TIME_LIMIT=900 for fault-injection coverage.
+#   make test-membership-single
+#   make test-membership-single FAULTS=partition TIME_LIMIT=900
+SINGLE_FAULTS ?= none
+test-membership-single: restart-stack
+	@echo "Starting single-learner membership test: faults=$(SINGLE_FAULTS) time=$(TIME_LIMIT)s"
+	docker exec -e SSH_AUTH_SOCK=/ssh-agent $(JEPSEN_CONTAINER) bash -c '\
+		  eval "$$(ssh-agent -s)" && \
+		  ssh-add /root/.ssh/id_rsa && \
+		  lein run test \
+		    --node '"${NODE1}"' \
+		    --node '"${NODE2}"' \
+		    --node '"${NODE3}"' \
+		    --node node4 \
+		    --node node5 \
+		    --endpoints '"${ENDPOINTS}"' \
+		    --time-limit '"${TIME_LIMIT}"' \
+		    --workload membership \
+		    --membership-mode single-learner \
+		    --faults '"${SINGLE_FAULTS}"' \
+		    --rate '"${RATE}"' \
+		    --nemesis-interval '"${NEMESIS_INTERVAL}"''
+	@echo "Single-learner membership test finished, checking result..."
+	docker exec $(JEPSEN_CONTAINER) bash -c '\
+		lein trampoline run -m clojure.main -e "\
+			(require '\''[knossos.model :as model])\
+			(println \
+				(if (-> (clojure.edn/read-string \
+					{:readers {\
+						'\''knossos.model.Register model/->Register\
+						'\''knossos.model.CASRegister model/->CASRegister\
+						'\''knossos.model.Inconsistent model/->Inconsistent}\
+					 :default (fn [_ v] v)}\
+					(slurp \"/app/store/latest/results.edn\"))\
+				:valid?)\
+				\"✅ PASS\" \"❌ FAIL\"))"'
 
 # High-concurrency stress test (RATE=200, 10 min).
 # Surfaces low-probability linearizability violations that 60s/rate=10 cannot.

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ d-engine-jepsen validates the following correctness properties:
 
 ### Workloads
 
-| Workload   | Checker                  | Description                              |
-| ---------- | ------------------------ | ---------------------------------------- |
-| `register` | Linearizable (Knossos)   | Single-key read/write                    |
-| `bank`     | Balance invariant        | Concurrent transfers across accounts     |
-| `set`      | Set membership           | Concurrent add/read                      |
-| `append`   | Elle (strict-serial)     | List-append with ordering anomaly detection |
-| `watch`    | Custom (order + phantom) | Watch stream delivers events in commit order |
+| Workload     | Checker                  | Description                              |
+| ------------ | ------------------------ | ---------------------------------------- |
+| `register`   | Linearizable (Knossos)   | Single-key read/write                    |
+| `bank`       | Balance invariant        | Concurrent transfers across accounts     |
+| `set`        | Set membership           | Concurrent add/read                      |
+| `append`     | Elle (strict-serial)     | List-append with ordering anomaly detection |
+| `watch`      | Custom (order + phantom) | Watch stream delivers events in commit order |
+| `membership` | Custom (stream invariants) | Dynamic node join: node4/5 start as Learners and auto-promote to Voters; `watch_membership` streams verified for monotone committed-index, no member/learner overlap, and non-empty members |
 
 ### What This Test Suite Guarantees
 
@@ -148,13 +149,14 @@ make test WORKLOAD=set FAULTS=kill,partition TIME_LIMIT=120 RATE=20
 
 **`WORKLOAD` — what to test:**
 
-| Value      | Tests what?                             | Checker |
-| ---------- | --------------------------------------- | ------- |
-| `register` | Single-key read/write is linearizable   | Knossos |
-| `bank`     | Transfers never lose or create money    | balance invariant |
-| `set`      | Every acknowledged add survives faults  | set-full |
-| `append`   | List-append has no ordering anomalies   | Elle |
-| `watch`    | Watch stream delivers events in commit order, no phantoms | custom |
+| Value        | Tests what?                             | Checker |
+| ------------ | --------------------------------------- | ------- |
+| `register`   | Single-key read/write is linearizable   | Knossos |
+| `bank`       | Transfers never lose or create money    | balance invariant |
+| `set`        | Every acknowledged add survives faults  | set-full |
+| `append`     | List-append has no ordering anomalies   | Elle |
+| `watch`      | Watch stream delivers events in commit order, no phantoms | custom |
+| `membership` | node4/5 join as Learners and promote to Voters; stream invariants hold | custom |
 
 **`FAULTS` — how to break the cluster:**
 

--- a/config/n4-readonly.toml
+++ b/config/n4-readonly.toml
@@ -1,0 +1,88 @@
+# Docker Jepsen config for node 4 — ReadOnly Learner.
+# Joins the existing 3-node cluster but will NEVER be promoted to Voter.
+# role = 4 (Learner), status = 2 (ReadOnly) per v0.2.3+ enum values.
+
+[cluster]
+node_id = 4
+listen_address = "192.168.0.15:9085"
+initial_cluster = [
+    { id = 1, address = "192.168.0.11:9081", role = 1, status = 3 },
+    { id = 2, address = "192.168.0.12:9082", role = 1, status = 3 },
+    { id = 3, address = "192.168.0.13:9083", role = 1, status = 3 },
+    { id = 4, address = "192.168.0.15:9085", role = 4, status = 2 },
+]
+db_root_dir = "./db/4"
+log_dir = "./logs"
+
+[raft]
+general_raft_timeout_duration_in_ms = 100
+cmd_channel_capacity = 1024
+ordered_channel_capacity = 1024
+
+[raft.election]
+election_timeout_min = 1000
+election_timeout_max = 2000
+
+[raft.read_consistency]
+default_policy = "LeaseRead"
+lease_duration_ms = 500
+
+[raft.batching]
+max_batch_size = 200
+
+[raft.metrics]
+enable_backpressure = false
+enable_batch = false
+
+[raft.backpressure]
+max_pending_writes = 1000
+max_pending_reads = 500
+
+[raft.persistence]
+strategy = "MemFirst"
+flush_policy = { Batch = { idle_flush_interval_ms = 1000 } }
+max_buffered_entries = 10000
+
+[raft.snapshot]
+enable = true
+max_log_entries_before_snapshot = 50
+snapshot_cool_down_since_last_check = { secs = 5 }
+snapshots_dir = "./snapshots/"
+retained_log_entries = 3
+
+[raft.state_machine.lease]
+enabled = true
+cleanup_interval_ms = 1000
+max_cleanup_duration_ms = 1
+
+[network.control]
+request_timeout_in_ms = 100
+concurrency_limit = 50
+max_concurrent_streams = 4096
+connection_window_size = 4_194_304
+initial_stream_window_size = 2_097_152
+enable_connect_protocol = true
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_max_pending_accept_reset_streams = 1000
+http2_max_send_buffer_size = 8_388_608
+
+[network.data]
+connect_timeout_in_ms = 100
+request_timeout_in_ms = 300
+concurrency_limit = 100
+max_concurrent_streams = 4096
+connection_window_size = 8_388_608
+initial_stream_window_size = 4_194_304
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_adaptive_window = true
+http2_max_pending_accept_reset_streams = 2000
+http2_max_send_buffer_size = 16_777_216
+
+[storage]
+unified_db = false

--- a/config/n4.toml
+++ b/config/n4.toml
@@ -1,0 +1,88 @@
+# Docker Jepsen config for node 4 (learner).
+# Joins the existing 3-node cluster as Learner and auto-promotes to Voter.
+# role = 4 (Learner), status = 1 (Promotable) per v0.2.3+ enum values.
+
+[cluster]
+node_id = 4
+listen_address = "192.168.0.15:9085"
+initial_cluster = [
+    { id = 1, address = "192.168.0.11:9081", role = 1, status = 3 },
+    { id = 2, address = "192.168.0.12:9082", role = 1, status = 3 },
+    { id = 3, address = "192.168.0.13:9083", role = 1, status = 3 },
+    { id = 4, address = "192.168.0.15:9085", role = 4, status = 1 },
+]
+db_root_dir = "./db/4"
+log_dir = "./logs"
+
+[raft]
+general_raft_timeout_duration_in_ms = 100
+cmd_channel_capacity = 1024
+ordered_channel_capacity = 1024
+
+[raft.election]
+election_timeout_min = 1000
+election_timeout_max = 2000
+
+[raft.read_consistency]
+default_policy = "LeaseRead"
+lease_duration_ms = 500
+
+[raft.batching]
+max_batch_size = 200
+
+[raft.metrics]
+enable_backpressure = false
+enable_batch = false
+
+[raft.backpressure]
+max_pending_writes = 1000
+max_pending_reads = 500
+
+[raft.persistence]
+strategy = "MemFirst"
+flush_policy = { Batch = { idle_flush_interval_ms = 1000 } }
+max_buffered_entries = 10000
+
+[raft.snapshot]
+enable = true
+max_log_entries_before_snapshot = 50
+snapshot_cool_down_since_last_check = { secs = 5 }
+snapshots_dir = "./snapshots/"
+retained_log_entries = 3
+
+[raft.state_machine.lease]
+enabled = true
+cleanup_interval_ms = 1000
+max_cleanup_duration_ms = 1
+
+[network.control]
+request_timeout_in_ms = 100
+concurrency_limit = 50
+max_concurrent_streams = 4096
+connection_window_size = 4_194_304
+initial_stream_window_size = 2_097_152
+enable_connect_protocol = true
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_max_pending_accept_reset_streams = 1000
+http2_max_send_buffer_size = 8_388_608
+
+[network.data]
+connect_timeout_in_ms = 100
+request_timeout_in_ms = 300
+concurrency_limit = 100
+max_concurrent_streams = 4096
+connection_window_size = 8_388_608
+initial_stream_window_size = 4_194_304
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_adaptive_window = true
+http2_max_pending_accept_reset_streams = 2000
+http2_max_send_buffer_size = 16_777_216
+
+[storage]
+unified_db = false

--- a/config/n5-readonly.toml
+++ b/config/n5-readonly.toml
@@ -1,0 +1,89 @@
+# Docker Jepsen config for node 5 — ReadOnly Learner.
+# Joins the existing cluster but will NEVER be promoted to Voter.
+# role = 4 (Learner), status = 2 (ReadOnly) per v0.2.3+ enum values.
+
+[cluster]
+node_id = 5
+listen_address = "192.168.0.16:9086"
+initial_cluster = [
+    { id = 1, address = "192.168.0.11:9081", role = 1, status = 3 },
+    { id = 2, address = "192.168.0.12:9082", role = 1, status = 3 },
+    { id = 3, address = "192.168.0.13:9083", role = 1, status = 3 },
+    { id = 4, address = "192.168.0.15:9085", role = 1, status = 3 },
+    { id = 5, address = "192.168.0.16:9086", role = 4, status = 2 },
+]
+db_root_dir = "./db/5"
+log_dir = "./logs"
+
+[raft]
+general_raft_timeout_duration_in_ms = 100
+cmd_channel_capacity = 1024
+ordered_channel_capacity = 1024
+
+[raft.election]
+election_timeout_min = 1000
+election_timeout_max = 2000
+
+[raft.read_consistency]
+default_policy = "LeaseRead"
+lease_duration_ms = 500
+
+[raft.batching]
+max_batch_size = 200
+
+[raft.metrics]
+enable_backpressure = false
+enable_batch = false
+
+[raft.backpressure]
+max_pending_writes = 1000
+max_pending_reads = 500
+
+[raft.persistence]
+strategy = "MemFirst"
+flush_policy = { Batch = { idle_flush_interval_ms = 1000 } }
+max_buffered_entries = 10000
+
+[raft.snapshot]
+enable = true
+max_log_entries_before_snapshot = 50
+snapshot_cool_down_since_last_check = { secs = 5 }
+snapshots_dir = "./snapshots/"
+retained_log_entries = 3
+
+[raft.state_machine.lease]
+enabled = true
+cleanup_interval_ms = 1000
+max_cleanup_duration_ms = 1
+
+[network.control]
+request_timeout_in_ms = 100
+concurrency_limit = 50
+max_concurrent_streams = 4096
+connection_window_size = 4_194_304
+initial_stream_window_size = 2_097_152
+enable_connect_protocol = true
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_max_pending_accept_reset_streams = 1000
+http2_max_send_buffer_size = 8_388_608
+
+[network.data]
+connect_timeout_in_ms = 100
+request_timeout_in_ms = 300
+concurrency_limit = 100
+max_concurrent_streams = 4096
+connection_window_size = 8_388_608
+initial_stream_window_size = 4_194_304
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_adaptive_window = true
+http2_max_pending_accept_reset_streams = 2000
+http2_max_send_buffer_size = 16_777_216
+
+[storage]
+unified_db = false

--- a/config/n5.toml
+++ b/config/n5.toml
@@ -1,0 +1,89 @@
+# Docker Jepsen config for node 5 (learner).
+# Joins the existing cluster (nodes 1-4) as Learner and auto-promotes to Voter.
+# role = 4 (Learner), status = 1 (Promotable) per v0.2.3+ enum values.
+
+[cluster]
+node_id = 5
+listen_address = "192.168.0.16:9086"
+initial_cluster = [
+    { id = 1, address = "192.168.0.11:9081", role = 1, status = 3 },
+    { id = 2, address = "192.168.0.12:9082", role = 1, status = 3 },
+    { id = 3, address = "192.168.0.13:9083", role = 1, status = 3 },
+    { id = 4, address = "192.168.0.15:9085", role = 1, status = 3 },
+    { id = 5, address = "192.168.0.16:9086", role = 4, status = 1 },
+]
+db_root_dir = "./db/5"
+log_dir = "./logs"
+
+[raft]
+general_raft_timeout_duration_in_ms = 100
+cmd_channel_capacity = 1024
+ordered_channel_capacity = 1024
+
+[raft.election]
+election_timeout_min = 1000
+election_timeout_max = 2000
+
+[raft.read_consistency]
+default_policy = "LeaseRead"
+lease_duration_ms = 500
+
+[raft.batching]
+max_batch_size = 200
+
+[raft.metrics]
+enable_backpressure = false
+enable_batch = false
+
+[raft.backpressure]
+max_pending_writes = 1000
+max_pending_reads = 500
+
+[raft.persistence]
+strategy = "MemFirst"
+flush_policy = { Batch = { idle_flush_interval_ms = 1000 } }
+max_buffered_entries = 10000
+
+[raft.snapshot]
+enable = true
+max_log_entries_before_snapshot = 50
+snapshot_cool_down_since_last_check = { secs = 5 }
+snapshots_dir = "./snapshots/"
+retained_log_entries = 3
+
+[raft.state_machine.lease]
+enabled = true
+cleanup_interval_ms = 1000
+max_cleanup_duration_ms = 1
+
+[network.control]
+request_timeout_in_ms = 100
+concurrency_limit = 50
+max_concurrent_streams = 4096
+connection_window_size = 4_194_304
+initial_stream_window_size = 2_097_152
+enable_connect_protocol = true
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_max_pending_accept_reset_streams = 1000
+http2_max_send_buffer_size = 8_388_608
+
+[network.data]
+connect_timeout_in_ms = 100
+request_timeout_in_ms = 300
+concurrency_limit = 100
+max_concurrent_streams = 4096
+connection_window_size = 8_388_608
+initial_stream_window_size = 4_194_304
+tcp_keepalive_in_secs = 60
+http2_keep_alive_interval_in_secs = 15
+http2_keep_alive_timeout_in_secs = 10
+max_frame_size = 16_777_215
+http2_adaptive_window = true
+http2_max_pending_accept_reset_streams = 2000
+http2_max_send_buffer_size = 16_777_216
+
+[storage]
+unified_db = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,47 @@ services:
       - "2023:22"
       - "9083:9083"
 
+  # node4 and node5 are learner nodes for the membership workload.
+  # They run sshd only on startup; the membership nemesis starts the demo
+  # binary via SSH when it's time for them to join the cluster.
+  node4:
+    <<: *node-base
+    environment:
+      ID: 4
+      PROMETHEUS_PORT: 8084
+      LISTEN_PORT: 9085
+      LOG_LEVEL: debug
+      CONFIG_PATH: config/n4
+      LOG_DIR: ./logs/4
+      METRICS_PORT: 8084
+    entrypoint: []
+    command: ["/usr/sbin/sshd", "-D"]
+    networks:
+      mynetwork:
+        ipv4_address: 192.168.0.15
+    ports:
+      - "2025:22"
+      - "9085:9085"
+
+  node5:
+    <<: *node-base
+    environment:
+      ID: 5
+      PROMETHEUS_PORT: 8085
+      LISTEN_PORT: 9086
+      LOG_LEVEL: debug
+      CONFIG_PATH: config/n5
+      LOG_DIR: ./logs/5
+      METRICS_PORT: 8085
+    entrypoint: []
+    command: ["/usr/sbin/sshd", "-D"]
+    networks:
+      mynetwork:
+        ipv4_address: 192.168.0.16
+    ports:
+      - "2026:22"
+      - "9086:9086"
+
   jepsen:
     image: jepsen:2.0
     build:

--- a/src/jepsen/d_engine.clj
+++ b/src/jepsen/d_engine.clj
@@ -7,16 +7,18 @@
             [client :as client]
             [generator :as gen]
             [independent :as independent]
+            [nemesis :as nemesis]
             [tests :as tests]]
    [jepsen.checker.timeline :as timeline]
    [knossos.model :as model]
-   [jepsen.d_engine.client  :as grpc]
-   [jepsen.d_engine.bank    :as bank]
-   [jepsen.d_engine.set     :as set-workload]
-   [jepsen.d_engine.append  :as append-workload]
-   [jepsen.d_engine.watch   :as watch-workload]
-   [jepsen.d_engine.db      :as db-module]
-   [jepsen.d_engine.nemesis :as d-nemesis]))
+   [jepsen.d_engine.client     :as grpc]
+   [jepsen.d_engine.bank       :as bank]
+   [jepsen.d_engine.set        :as set-workload]
+   [jepsen.d_engine.append     :as append-workload]
+   [jepsen.d_engine.watch      :as watch-workload]
+   [jepsen.d_engine.membership :as membership-workload]
+   [jepsen.d_engine.db         :as db-module]
+   [jepsen.d_engine.nemesis    :as d-nemesis]))
 
 ;; ========== Nemesis spec ==========
 
@@ -76,10 +78,11 @@
 
 (defn workload [opts]
   (case (:workload opts)
-    "bank"   (bank/workload opts)
-    "set"    (set-workload/workload opts)
-    "append" (append-workload/workload opts)
-    "watch"  (watch-workload/workload opts)
+    "bank"       (bank/workload opts)
+    "set"        (set-workload/workload opts)
+    "append"     (append-workload/workload opts)
+    "watch"      (watch-workload/workload opts)
+    "membership" (membership-workload/workload opts)
     (register-workload opts)))
 
 ;; ========== Test spec ==========
@@ -95,13 +98,36 @@
                :pause     {:targets [:all]}
                :kill      {:targets [:minority]}
                :interval  (:nemesis-interval opts)})
+        [combined-nemesis combined-nem-gen]
+        (if-let [m-nem (:membership-nemesis wl)]
+          (let [regular-nem (:nemesis nem)]
+            [(reify nemesis/Nemesis
+               (setup! [this test]
+                 (nemesis/setup! regular-nem test)
+                 (nemesis/setup! m-nem test)
+                 this)
+               (invoke! [this test op]
+                 (if (= :join-node (:f op))
+                   (nemesis/invoke! m-nem test op)
+                   (nemesis/invoke! regular-nem test op)))
+               (teardown! [this test]
+                 (nemesis/teardown! regular-nem test)
+                 (nemesis/teardown! m-nem test)
+                 this))
+             ;; Membership joins run first (stable window), then fault injection.
+             ;; gen/mix would fire join-node right after stop-partition, before
+             ;; the cluster has a stable leader — causing immediate d-engine crashes.
+             (gen/phases
+               (:membership-nem-generator wl)
+               (:generator nem))])
+          [(:nemesis nem) (:generator nem)])
         gen (gen/phases
               (->> (:generator wl)
                    (gen/stagger (/ 1 (:rate opts)))
                    (gen/nemesis
                      (gen/phases
                        (gen/sleep 5)
-                       (:generator nem)))
+                       combined-nem-gen))
                    (gen/time-limit (:time-limit opts)))
               (gen/log "Healing cluster")
               (gen/nemesis (:final-generator nem))
@@ -115,7 +141,7 @@
                         :strict-host-key-checking false}
             :db        db
             :client    (:client wl)
-            :nemesis   (:nemesis nem)
+            :nemesis   combined-nemesis
             :checker   (:checker wl)
             :generator gen})))
 
@@ -127,10 +153,18 @@
     :parse-fn identity
     :validate [(complement empty?) "endpoints cannot be empty."]]
 
-   ["-w" "--workload NAME" "Workload: register (default), bank, set, append, watch"
+   ["-w" "--workload NAME" "Workload: register (default), bank, set, append, watch, membership"
     :default  "register"
     :parse-fn identity
-    :validate [#{"register" "bank" "set" "append" "watch"} "must be one of: register, bank, set, append, watch"]]
+    :validate [#{"register" "bank" "set" "append" "watch" "membership"}
+               "must be one of: register, bank, set, append, watch, membership"]]
+
+   [nil "--membership-mode MODE"
+    "Membership workload mode: promotable (default), readonly, single-learner"
+    :default  "promotable"
+    :parse-fn identity
+    :validate [#{"promotable" "readonly" "single-learner"}
+               "must be one of: promotable, readonly, single-learner"]]
 
    [nil "--faults FAULTS" "Nemesis faults (comma-separated: partition,kill,pause / all / none)"
     :default  [:partition]

--- a/src/jepsen/d_engine/db.clj
+++ b/src/jepsen/d_engine/db.clj
@@ -14,6 +14,7 @@
 (defn node-id [node]
   (case node
     "node1" 1 "node2" 2 "node3" 3
+    "node4" 4 "node5" 5
     (throw (ex-info "Unknown node" {:node node}))))
 
 (defn kill!
@@ -22,24 +23,24 @@
   (c/su (cu/grepkill! binary)))
 
 (defn start!
-  "Starts the demo binary if not already running.
-  Uses start-stop-daemon --background (double-fork) to fully escape the
-  sudo session that nohup/setsid cannot break out of."
-  [node]
-  (let [id    (node-id node)
-        conf  (str "/app/config/n" id)
-        log   (str "/app/logs/" id)
-        mport (+ 8080 id)]
-    (c/su
-      (cu/start-daemon!
-        {:logfile logfile
-         :pidfile "/app/demo.pid"
-         :chdir   "/app"
-         :env     {"CONFIG_PATH"  conf
-                   "LOG_DIR"      log
-                   "METRICS_PORT" (str mport)
-                   "RUST_LOG"     "demo=debug,d_engine=debug,hyper=warn,sled=warn"}}
-        "/usr/local/bin/demo"))))
+  "Starts the demo binary. config-override optionally replaces the default
+  /app/config/nN path (e.g. \"/app/config/n4-readonly\" for ReadOnly mode)."
+  ([node] (start! node nil))
+  ([node config-override]
+   (let [id    (node-id node)
+         conf  (or config-override (str "/app/config/n" id))
+         log   (str "/app/logs/" id)
+         mport (+ 8080 id)]
+     (c/su
+       (cu/start-daemon!
+         {:logfile logfile
+          :pidfile "/app/demo.pid"
+          :chdir   "/app"
+          :env     {"CONFIG_PATH"  conf
+                    "LOG_DIR"      log
+                    "METRICS_PORT" (str mport)
+                    "RUST_LOG"     "demo=debug,d_engine=debug,hyper=warn,sled=warn"}}
+         "/usr/local/bin/demo")))))
 
 (defrecord DB []
   db/DB
@@ -75,7 +76,7 @@
            (remove nil?))))
 
   db/Process
-  (start! [_ test node] (start! node))
+  (start! [_ test node] (start! node nil))
   (kill!  [_ test node] (kill!))
 
   db/Pause

--- a/src/jepsen/d_engine/membership.clj
+++ b/src/jepsen/d_engine/membership.clj
@@ -1,0 +1,299 @@
+(ns jepsen.d_engine.membership
+  "Membership workload: verifies dynamic cluster expansion under fault injection.
+
+   Modes
+   -----
+   :promotable     (default) — node4 + node5 join as Promotable Learners (status=1).
+                   3+2=5 voters → both auto-promote via BatchPromote ConfChange.
+                   Checker: safety invariants + liveness (4 and 5 eventually in members).
+
+   :readonly       — node4 + node5 join with ReadOnly status (status=2).
+                   Never promoted to Voters regardless of how many join.
+                   Checker: safety invariants + 4/5 never appear in members.
+
+   :single-learner — only node4 joins a 3-node cluster (3+1=4, even → batch_size=0).
+                   Cannot promote; after stale_learner_threshold (default 300s) the
+                   leader submits BatchRemove and node4 is expelled.
+                   Checker: safety invariants + node4 never in members + eventually
+                   leaves learners. Requires TIME_LIMIT >= 420."
+  (:require [clojure.set :as set]
+            [clojure.tools.logging :refer [info warn]]
+            [jepsen [checker   :as checker]
+                    [client    :as client]
+                    [control   :as c]
+                    [generator :as gen]
+                    [nemesis   :as nemesis]]
+            [jepsen.d_engine.client :as grpc]
+            [jepsen.d_engine.db     :as db])
+  (:import [d_engine.client ClientApi$WatchMembershipRequest
+                             RaftClientServiceGrpc]
+           [io.grpc Status$Code StatusRuntimeException]
+           [java.util.concurrent TimeUnit]))
+
+(def ^:private watch-window-ms 3000)
+(def ^:private write-key 0)
+(def next-write (atom 0))
+
+;; ── Snapshot collection ───────────────────────────────────────────────────────
+
+(defn- collect-snapshots
+  "Opens a WatchMembership stream on ch. Drains snapshots until the
+  watch-window-ms deadline fires (DEADLINE_EXCEEDED), then returns a vector
+  of {:members [...] :learners [...] :committed-index n}.
+  Returns [] on any other stream error."
+  [ch]
+  (try
+    (let [req  (-> (ClientApi$WatchMembershipRequest/newBuilder)
+                   (.setClientId 99)
+                   (.build))
+          stub (-> (RaftClientServiceGrpc/newBlockingStub ch)
+                   (.withDeadlineAfter watch-window-ms TimeUnit/MILLISECONDS))
+          iter (.watchMembership stub req)]
+      (loop [snapshots []]
+        (let [[more? snapshots']
+              (try
+                (if (.hasNext iter)
+                  (let [snap (.next iter)]
+                    [true (conj snapshots
+                                {:members        (vec (.getMembersList snap))
+                                 :learners        (vec (.getLearnersList snap))
+                                 :committed-index (.getCommittedIndex snap)})])
+                  [false snapshots])
+                (catch StatusRuntimeException e
+                  (when-not (= (.getCode (.getStatus e)) Status$Code/DEADLINE_EXCEEDED)
+                    (warn "watch-membership stream error" (str (.getStatus e))))
+                  [false snapshots]))]
+          (if more?
+            (recur snapshots')
+            snapshots'))))
+    (catch Exception e
+      (warn "collect-snapshots error" (str e))
+      [])))
+
+;; ── Client ───────────────────────────────────────────────────────────────────
+
+(defrecord MembershipClient [endpoints channels]
+  client/Client
+
+  (open! [this test node]
+    (assoc this :channels (grpc/open-all-channels endpoints)))
+
+  (setup! [this test])
+
+  (invoke! [this test op]
+    (case (:f op)
+      :write
+      (let [res (grpc/put! channels write-key (:value op))]
+        (case (:type res)
+          :ok   (assoc op :type :ok)
+          :info (assoc op :type :info :error (:error res))
+          :fail (assoc op :type :fail :error (:error res))))
+
+      :watch-membership
+      (let [ch    (rand-nth channels)
+            snaps (collect-snapshots ch)]
+        (assoc op :type :ok :value snaps))))
+
+  (teardown! [this test])
+
+  (close! [this test]
+    (when channels (grpc/close-all-channels channels))))
+
+;; ── Membership nemesis ───────────────────────────────────────────────────────
+
+(defn- process-running? [node]
+  (try (c/on node (c/exec :pgrep :-f "demo")) true
+       (catch Exception _ false)))
+
+(defn membership-nemesis []
+  "A nemesis that starts learner nodes via SSH, retrying if d-engine crashes
+   on leader discovery (e.g. immediately after a partition heal)."
+  (reify nemesis/Nemesis
+    (setup! [this test] this)
+
+    (invoke! [this test op]
+      (case (:f op)
+        :join-node
+        (let [{:keys [node config]} (if (string? (:value op))
+                                      {:node (:value op) :config nil}
+                                      (:value op))]
+          (try
+            (loop [attempt 1]
+              (info "membership-nemesis: starting" node
+                    (if config (str "config=" config) "(default config)")
+                    (when (> attempt 1) (str "attempt " attempt)))
+              (c/on node (db/start! node config))
+              (Thread/sleep 3000)
+              (if (process-running? node)
+                (assoc op :type :info :value {:node node :result :started :attempt attempt})
+                (if (< attempt 5)
+                  (do (warn "membership-nemesis:" node "crashed (attempt" attempt "), retrying in 5s")
+                      (Thread/sleep 5000)
+                      (recur (inc attempt)))
+                  (do (warn "membership-nemesis:" node "failed after 5 attempts")
+                      (assoc op :type :info :value {:node node :result :failed})))))
+            (catch Exception e
+              (warn "membership-nemesis: error starting" node (str e))
+              (assoc op :type :info :value {:node node :result :error :error (str e)}))))
+
+        (assoc op :type :info :value :not-handled)))
+
+    (teardown! [this test] this)))
+
+;; ── Nemesis generators ────────────────────────────────────────────────────────
+
+(defn- nemesis-gen [mode]
+  ;; No trailing sleep: the generator completes after all joins fire,
+  ;; allowing d_engine.clj to sequence fault injection afterwards.
+  (case mode
+    :promotable
+    (gen/phases
+      (gen/sleep 10)
+      {:type :info :f :join-node :value {:node "node4"}}
+      (gen/sleep 5)
+      {:type :info :f :join-node :value {:node "node5"}})
+
+    :readonly
+    (gen/phases
+      (gen/sleep 10)
+      {:type :info :f :join-node :value {:node "node4" :config "/app/config/n4-readonly"}}
+      (gen/sleep 10)
+      {:type :info :f :join-node :value {:node "node5" :config "/app/config/n5-readonly"}})
+
+    :single-learner
+    (gen/phases
+      (gen/sleep 30)
+      {:type :info :f :join-node :value {:node "node4"}})))
+
+;; ── Client generators ─────────────────────────────────────────────────────────
+
+(defn write-op [_ _]
+  {:type :invoke :f :write :value (swap! next-write inc)})
+
+(defn watch-membership-op [_ _]
+  {:type :invoke :f :watch-membership :value nil})
+
+;; ── Checker helpers ───────────────────────────────────────────────────────────
+
+(defn- snaps-from
+  "All watch-membership :ok snapshots flattened in history order."
+  [history]
+  (->> history
+       (filter #(and (= :watch-membership (:f %)) (= :ok (:type %))))
+       (mapcat :value)))
+
+(defn- check-safety
+  "Safety invariants shared across all modes."
+  [history]
+  (let [watch-ops (->> history
+                       (filter #(and (= :watch-membership (:f %)) (= :ok (:type %))))
+                       (group-by :process))
+        bad-index
+        (for [[proc ops] watch-ops
+              op         ops
+              :let       [snaps (:value op)]
+              [a b]      (partition 2 1 snaps)
+              :when      (> (:committed-index a) (:committed-index b))]
+          {:process proc
+           :prev-index (:committed-index a)
+           :next-index (:committed-index b)})
+
+        bad-overlap
+        (for [[proc ops] watch-ops
+              op         ops
+              snap       (:value op)
+              :let       [overlap (set/intersection
+                                    (set (:members snap))
+                                    (set (:learners snap)))]
+              :when      (seq overlap)]
+          {:process proc :snapshot snap :overlap (vec overlap)})
+
+        bad-empty
+        (for [[proc ops] watch-ops
+              op         ops
+              snap       (:value op)
+              :when      (empty? (:members snap))]
+          {:process proc :snapshot snap})]
+    {:bad-index   (vec (take 10 bad-index))
+     :bad-overlap (vec (take 10 bad-overlap))
+     :bad-empty   (vec (take 10 bad-empty))}))
+
+(defn- check-promotable
+  "Liveness: node4 and node5 must eventually appear in members."
+  [snaps]
+  (let [node4? (some #(some #{4} (:members %)) snaps)
+        node5? (some #(some #{5} (:members %)) snaps)]
+    (cond-> {}
+      (not node4?) (assoc :node4-not-promoted true)
+      (not node5?) (assoc :node5-not-promoted true))))
+
+(defn- check-readonly
+  "Safety: node4 and node5 must never appear in members."
+  [snaps]
+  (let [bad (filter #(or (some #{4} (:members %))
+                         (some #{5} (:members %)))
+                    snaps)]
+    (if (seq bad)
+      {:readonly-nodes-promoted (vec (take 5 bad))}
+      {})))
+
+(defn- check-single-learner
+  "Safety: node4 never in members.
+   Liveness: node4 appears in learners, then eventually disappears (BatchRemove).
+   Requires TIME_LIMIT >= 420s to observe BatchRemove."
+  [snaps]
+  (let [in-members?  #(some #{4} (:members %))
+        in-learners? #(some #{4} (:learners %))
+        promoted     (filter in-members? snaps)
+        appeared?    (some in-learners? snaps)
+        indexed      (map-indexed vector snaps)
+        last-in-idx  (reduce (fn [acc [i s]] (if (in-learners? s) i acc)) nil indexed)
+        removed?     (when last-in-idx
+                       (some (fn [[i s]]
+                               (and (> i last-in-idx)
+                                    (not (in-learners? s))
+                                    (not (in-members? s))))
+                             indexed))]
+    (cond-> {}
+      (seq promoted)                  (assoc :node4-promoted           (vec (take 3 promoted)))
+      (not appeared?)                 (assoc :node4-never-appeared     true)
+      (and appeared? (not removed?))  (assoc :node4-not-removed        true))))
+
+;; ── Checker ───────────────────────────────────────────────────────────────────
+
+(defn checker [mode]
+  (reify checker/Checker
+    (check [_ test history opts]
+      (let [safety       (check-safety history)
+            snaps        (snaps-from history)
+            window-count (->> history
+                              (filter #(and (= :watch-membership (:f %))
+                                           (= :ok (:type %))))
+                              count)
+            mode-errors  (case mode
+                           :promotable     (check-promotable snaps)
+                           :readonly       (check-readonly snaps)
+                           :single-learner (check-single-learner snaps))
+            valid?       (and (empty? (:bad-index safety))
+                              (empty? (:bad-overlap safety))
+                              (empty? (:bad-empty safety))
+                              (empty? mode-errors))]
+        (cond-> {:valid?       valid?
+                 :mode         (name mode)
+                 :window-count window-count}
+          (seq (:bad-index safety))   (assoc :index-errors   (:bad-index safety))
+          (seq (:bad-overlap safety)) (assoc :overlap-errors (:bad-overlap safety))
+          (seq (:bad-empty safety))   (assoc :empty-errors   (:bad-empty safety))
+          (seq mode-errors)           (merge mode-errors))))))
+
+;; ── Workload ─────────────────────────────────────────────────────────────────
+
+(defn workload [opts]
+  (let [mode (keyword (get opts :membership-mode "promotable"))]
+    (reset! next-write (quot (System/currentTimeMillis) 1000))
+    {:client                    (MembershipClient. (:endpoints opts) nil)
+     :checker                   (checker mode)
+     :generator                 (gen/reserve 1 write-op watch-membership-op)
+     :final-generator           (gen/once watch-membership-op)
+     :membership-nemesis        (membership-nemesis)
+     :membership-nem-generator  (nemesis-gen mode)}))


### PR DESCRIPTION
## Changes

- `docker-compose.yml`: add node4 and node5 services (sshd-only on startup,
  demo binary started by membership nemesis via SSH at test time); fixed IPs
  192.168.0.15/16, ports 9085/9086
- `README.md`: add `membership` workload to both the workload reference tables

## Note

Code changes for the membership workload (membership.clj, config files,
d_engine.clj, db.clj, Makefile, GUARANTEES.md) were merged in the prior PR.
This PR contains only the infrastructure and documentation files that were
accidentally omitted from that commit.
